### PR TITLE
Promote after first tool call or reply; harden the bootstrap filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Anchored Standard separates initial trajectory selection from later tool use:
 
 1. Keep the Minimal complete system prompt.
 2. Expose only the platform shell plus `read` on the first model request.
-3. After the session records its first `tool/call`, expose all Standard tools.
+3. After the session records its first durable promotion signal — a `tool/call`
+   or the first `assistant/message`, whichever comes first — expose all
+   Standard tools. Request #1 always sees the bootstrap catalog; request #2
+   always sees the full catalog, so a text-only first reply can no longer trap
+   the session in bootstrap. (`promoteOn` in the `tool-bootstrap` row selects
+   the trigger: `either` default, `tool-call`, or `assistant-message`.)
 4. Derive the phase from durable session events so resume and reload preserve it.
 
 On Windows the bootstrap catalog is `pwsh/read`; on Linux it is `bash/read`.
@@ -85,8 +90,8 @@ different preset.
 Export the session JSONL and inspect `request/header` events:
 
 - the first header should contain only `pwsh/read` or `bash/read`;
-- after the first tool call, the next changed header should contain the full
-  Standard catalog;
+- after the first tool call or the first assistant reply, the next changed
+  header should contain the full Standard catalog;
 - subsequent requests should keep that full catalog.
 
 Run the local zero-dependency tests with:
@@ -97,9 +102,19 @@ npm test
 
 ## Important behavior
 
-- If the first model response makes no tool call, promotion does not occur.
+- With the default `promoteOn: either`, the session promotes after its first
+  durable `tool/call` OR its first `assistant/message`, whichever comes first —
+  request #1 sees the bootstrap catalog and every later request sees the full
+  catalog. A text-only first reply therefore still promotes at request #2;
+  set `promoteOn: tool-call` to restore the original behavior, where a first
+  response that makes no tool call never promotes.
 - A failed tool execution still promotes the session because the durable
   `tool/call` already exists.
+- A missing bootstrap tool degrades to the full catalog with a one-time
+  warning instead of failing requests, so a composition drift cannot brick a
+  session; invalid `promoteOn` values fail at preset mount instead.
+- Promotion decisions are memoized per session for the process lifetime; the
+  durable event scan runs once per session per process.
 - The tool catalog changes once, so request-prefix cache continuity also changes
   once between the first and second model requests.
 - The preset has the same trust level as shell access. Review its files before

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,8 +3,8 @@
 [English](./README.md)
 
 这是一个实验性的 DeepSeek Harness agent preset：第一次模型请求使用与 Minimal 对齐的
-完整 system prompt 和两项工具；会话记录首次持久 `tool/call` 后，开放 Standard 的完整
-工具目录。
+完整 system prompt 和两项工具；会话记录首次持久晋升信号（`tool/call` 或首次
+`assistant/message`，先到者为准）后，开放 Standard 的完整工具目录。
 
 这是社区项目，并非 DeepSeek 官方 preset，也不代表 DeepSeek 的认可或背书。
 
@@ -18,7 +18,10 @@ Anchored Standard 把“首次轨迹选择”和“后续完整工具能力”�
 
 1. 保持 Minimal 的完整 system prompt；
 2. 首次模型请求只暴露当前平台 shell 和 `read`；
-3. 会话出现首次 `tool/call` 后开放全部 Standard 工具；
+3. 会话出现首次持久晋升信号（`tool/call` 或首次 `assistant/message`，先到者为准）
+   后开放全部 Standard 工具——请求 #1 恒为 bootstrap 目录，请求 #2 起恒为完整目录，
+   纯文字首答不再把会话困死在 bootstrap（`tool-bootstrap` 行的 `promoteOn` 可选
+   `either` 默认 / `tool-call` / `assistant-message`）；
 4. 从持久 session event 推导阶段，resume 和 reload 不会丢失状态。
 
 Windows 首次目录为 `pwsh/read`，Linux 为 `bash/read`。
@@ -80,7 +83,7 @@ cp -R preset "$dsh_home/.agent-presets/anchored-standard"
 导出 session JSONL，检查 `request/header`：
 
 - 第一份 header 应只有 `pwsh/read` 或 `bash/read`；
-- 首次工具调用后，下一份变更 header 应包含完整 Standard 目录；
+- 首次工具调用或首次助手回复后，下一份变更 header 应包含完整 Standard 目录；
 - 此后的请求应保持完整目录。
 
 本仓库的零依赖测试：
@@ -91,8 +94,14 @@ npm test
 
 ## 重要行为
 
-- 第一次模型响应如果没有调用工具，会话不会晋升；
+- 默认 `promoteOn: either`：会话在首次持久 `tool/call` **或** 首次 `assistant/message`
+  （先到者为准）后晋升——请求 #1 见 bootstrap 目录，之后所有请求见完整目录；纯文字
+  首答也会在请求 #2 晋升。改为 `promoteOn: tool-call` 可恢复原行为（首答不调工具则
+  永不晋升）；
 - 工具执行即使失败，只要 `tool/call` 已持久化，下一步仍会晋升；
+- bootstrap 工具缺失时降级为完整目录并一次性告警，不再让请求失败，组合漂移不会锁死
+  会话；非法的 `promoteOn` 值会在 preset 挂载时报错；
+- 晋升判定按会话在进程内记忆化，持久事件扫描每会话每进程只执行一次。
 - 工具目录只变化一次，因此第一、第二次请求之间也会发生一次前缀缓存变化；
 - preset 与 shell 访问具有相同信任等级，安装前应自行审阅文件；
 - 插件不会发起网络请求，也不增加遥测。

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -37,13 +37,18 @@
     maxBytes: 65536
 
 # V4 Pro conditions strongly on the API tool catalog. Bootstrap its first model
-# request with one native shell plus `read`; after the first durable tool call,
-# later step assemblies expose every Standard tool registered below.
+# request with one native shell plus `read`; after the session records its first
+# durable promotion signal (a tool call OR the first assistant message, default
+# `promoteOn: either`), later step assemblies expose every Standard tool
+# registered below. Request #1 always sees the bootstrap catalog; request #2
+# always sees the full catalog — a text-only first reply can no longer trap the
+# session in bootstrap. See tool-bootstrap.mjs for the other triggers.
 - id: tool-bootstrap
   name: ./tool-bootstrap.mjs
   config:
     shellTools: [bash, pwsh]
     commonTools: [read]
+    promoteOn: either
 
 # ── shell ───────────────────────────────────────────────────────────────────
 

--- a/preset/preset.yml
+++ b/preset/preset.yml
@@ -1,3 +1,3 @@
 name: Anchored Standard (experimental)
-description: Bootstrap with shell/read, then expose the full Standard tool catalog after the first durable tool call.
+description: Bootstrap with shell/read, then expose the full Standard tool catalog after the first durable tool call or reply.
 order: 5

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -1,6 +1,25 @@
 /**
- * Keep the first model request on a small tool surface, then expose the full
- * preset catalog after the model has produced its first durable tool call.
+ * Anchored tool bootstrap — keep the FIRST model request on a small tool
+ * surface, then expose the full preset catalog once the session has produced
+ * its first durable promotion signal.
+ *
+ * The phase is derived from durable session events, so resume and reload
+ * preserve it. By default (`promoteOn: 'either'`) a session promotes after the
+ * first `tool/call` OR the first `assistant/message`, whichever comes first:
+ * request #1 always sees the bootstrap catalog and request #2 always sees the
+ * full catalog. The original `'tool-call'` mode is kept for compatibility, but
+ * it can trap a session in bootstrap forever when the first model reply makes
+ * no tool call — the `'either'` default removes that trap while keeping the
+ * first-request anchor intact.
+ *
+ * Robustness:
+ *  - Promotion decisions are memoized per session id for this process; the
+ *    durable event scan runs once per session per process, then O(1).
+ *  - A missing bootstrap tool degrades to the full catalog with a one-time
+ *    warning instead of throwing, so a composition drift can never brick
+ *    every request of a session.
+ *  - Invalid config (bad tool lists, unknown `promoteOn`) fails at apply
+ *    time, i.e. at preset mount, where it is visible and fixable.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -9,39 +28,89 @@ export const name = 'anchored-tool-bootstrap'
 /** Prompt assembly must exist before this request filter can register. */
 export const inject = ['systemPrompt']
 
+/** Durable session event types that count as a promotion signal per mode. */
+const PROMOTE_EVENTS = {
+  'tool-call': ['tool/call'],
+  'assistant-message': ['assistant/message'],
+  either: ['tool/call', 'assistant/message'],
+}
+
 function stringList(value, field) {
-  if (!Array.isArray(value) || value.length === 0 || value.some(item => typeof item !== 'string' || item.length === 0)) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
     throw new TypeError(`${name}: ${field} must be a non-empty array of non-empty strings`)
   }
   return [...new Set(value)]
+}
+
+function parsePromoteOn(value) {
+  if (value === undefined || value === 'either') return PROMOTE_EVENTS.either
+  if (value === 'tool-call' || value === 'assistant-message') return PROMOTE_EVENTS[value]
+  throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
 }
 
 /** Register the per-session bootstrap filter. */
 export function apply(ctx, config) {
   const commonTools = stringList(config.commonTools, 'commonTools')
   const shellTools = stringList(config.shellTools, 'shellTools')
+  const promoteEvents = parsePromoteOn(config.promoteOn)
 
-  ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
-    const assembled = await next()
-    const agent = context.agent
-    if (agent === undefined || agent.session.events.some(event => event.type === 'tool/call')) {
+  /** Sessions already promoted in this process. Promotion is append-only, so a Set is sound. */
+  const promoted = new Set()
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  /**
+   * Whether the session has reached the promoted phase.
+   * @param agent - the assembly context's agent, or undefined outside an agent.
+   */
+  const isPromoted = (agent) => {
+    if (agent === undefined) return true
+    const session = agent.session
+    if (session === undefined) return true
+    if (promoted.has(session.id)) return true
+    const hit = session.events.some((event) => promoteEvents.includes(event.type))
+    if (hit) promoted.add(session.id)
+    return hit
+  }
+
+  /** Narrow the assembled catalog to one platform shell plus the common tools. */
+  const applyBootstrap = (assembled) => {
+    const available = new Set(assembled.tools.map((tool) => tool.name))
+    const selectedShells = shellTools.filter((toolName) => available.has(toolName))
+    const missingCommon = commonTools.filter((toolName) => !available.has(toolName))
+    if (selectedShells.length !== 1 || missingCommon.length > 0) {
+      warnOnce(
+        `${name}: expected exactly one bootstrap shell and every common tool; `
+        + `shells=${JSON.stringify(selectedShells)}, missing=${JSON.stringify(missingCommon)} — `
+        + 'bootstrap disabled, full catalog exposed',
+      )
       return assembled
     }
-
-    const available = new Set(assembled.tools.map(tool => tool.name))
-    const selectedShells = shellTools.filter(toolName => available.has(toolName))
-    const missingCommon = commonTools.filter(toolName => !available.has(toolName))
-    if (selectedShells.length !== 1 || missingCommon.length > 0) {
-      throw new Error(
-        `${name}: expected exactly one bootstrap shell and every common tool; `
-        + `shells=${JSON.stringify(selectedShells)}, missing=${JSON.stringify(missingCommon)}`,
-      )
-    }
-
     const bootstrap = new Set([...selectedShells, ...commonTools])
     return {
       ...assembled,
-      tools: assembled.tools.filter(tool => bootstrap.has(tool.name)),
+      tools: assembled.tools.filter((tool) => bootstrap.has(tool.name)),
+    }
+  }
+
+  ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is guarded.
+    const assembled = await next()
+    try {
+      if (isPromoted(context.agent)) return assembled
+      return applyBootstrap(assembled)
+    } catch (error) {
+      // A filter bug must never brick a session: degrade to the full catalog.
+      warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
+      return assembled
     }
   })
 }

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -8,23 +8,29 @@ const config = {
   shellTools: ['bash', 'pwsh'],
 }
 
-function register() {
+function register(cfg = config) {
   let listener
+  const warns = []
   const ctx = {
     on(event, callback) {
       assert.equal(event, 'system-prompt/assemble')
       listener = callback
     },
+    logger: {
+      warn(message) {
+        warns.push(message)
+      },
+    },
   }
-  apply(ctx, config)
+  apply(ctx, cfg)
   assert.equal(typeof listener, 'function')
-  return listener
+  return { listener, warns }
 }
 
-async function assemble(listener, events, tools) {
+function assemble(listener, events, tools, id = 's') {
   return listener(
     undefined,
-    { agent: { session: { events } } },
+    { agent: { session: { id, events } } },
     async () => ({ system: 'minimal persona', tools }),
   )
 }
@@ -34,42 +40,69 @@ test('exports a diagnostic plugin name', () => {
 })
 
 test('first request exposes one platform shell and read', async () => {
-  const listener = register()
-  const tools = [
-    { name: 'pwsh' },
-    { name: 'read' },
-    { name: 'edit' },
-  ]
+  const { listener } = register()
+  const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'edit' }]
   const result = await assemble(listener, [], tools)
-  assert.deepEqual(result.tools.map(tool => tool.name), ['pwsh', 'read'])
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['pwsh', 'read'])
 })
 
 test('a durable tool call promotes the complete catalog', async () => {
-  const listener = register()
-  const tools = [
-    { name: 'pwsh' },
-    { name: 'read' },
-    { name: 'edit' },
-    { name: 'grep' },
-  ]
-  const events = [{ type: 'tool/call', data: { name: 'read' } }]
-  const result = await assemble(listener, events, tools)
+  const { listener } = register()
+  const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'edit' }, { name: 'grep' }]
+  const result = await assemble(listener, [{ type: 'tool/call', data: { name: 'read' } }], tools)
+  assert.deepEqual(result.tools, tools)
+})
+
+test('a first assistant message promotes the complete catalog (no tool call needed)', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'write' }]
+  const result = await assemble(listener, [{ type: 'assistant/message', data: {} }], tools)
   assert.deepEqual(result.tools, tools)
 })
 
 test('sessions derive promotion independently from their own events', async () => {
-  const listener = register()
+  const { listener } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const promoted = await assemble(listener, [{ type: 'tool/call' }], tools)
-  const fresh = await assemble(listener, [], tools)
+  const promoted = await assemble(listener, [{ type: 'tool/call' }], tools, 'a')
+  const fresh = await assemble(listener, [], tools, 'b')
   assert.deepEqual(promoted.tools, tools)
-  assert.deepEqual(fresh.tools.map(tool => tool.name), ['bash', 'read'])
+  assert.deepEqual(fresh.tools.map((tool) => tool.name), ['bash', 'read'])
 })
 
-test('misconfigured bootstrap catalogs fail loudly', async () => {
-  const listener = register()
-  await assert.rejects(
-    assemble(listener, [], [{ name: 'read' }, { name: 'edit' }]),
-    /expected exactly one bootstrap shell/,
-  )
+test('promotion is memoized per session id within one process', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+  const first = await assemble(listener, [{ type: 'tool/call' }], tools, 'memo')
+  assert.deepEqual(first.tools, tools)
+  // Same session id, events now empty: the cached decision still promotes.
+  const second = await assemble(listener, [], tools, 'memo')
+  assert.deepEqual(second.tools, tools)
+})
+
+test('promoteOn tool-call requires a tool call, not just a reply', async () => {
+  const { listener } = register({ ...config, promoteOn: 'tool-call' })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+  const replyOnly = await assemble(listener, [{ type: 'assistant/message' }], tools, 'a')
+  assert.deepEqual(replyOnly.tools.map((tool) => tool.name), ['bash', 'read'])
+  const withCall = await assemble(listener, [{ type: 'tool/call' }], tools, 'b')
+  assert.deepEqual(withCall.tools, tools)
+})
+
+test('promoteOn assistant-message promotes after any first reply', async () => {
+  const { listener } = register({ ...config, promoteOn: 'assistant-message' })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+  const result = await assemble(listener, [{ type: 'assistant/message' }], tools, 'a')
+  assert.deepEqual(result.tools, tools)
+})
+
+test('a missing bootstrap shell degrades gracefully to the full catalog', async () => {
+  const { listener, warns } = register()
+  const tools = [{ name: 'read' }, { name: 'edit' }]
+  const result = await assemble(listener, [], tools)
+  assert.deepEqual(result.tools, tools)
+  assert.ok(warns.length >= 1)
+})
+
+test('invalid promoteOn values fail at apply time', () => {
+  assert.throws(() => register({ ...config, promoteOn: 'bogus' }), /promoteOn/)
 })


### PR DESCRIPTION
## Summary

Two fixes plus one optimization to `tool-bootstrap.mjs`, with the READMEs and tests aligned.

### 1. No more permanent bootstrap trap (behavior change, default `promoteOn: either`)

Previously a session promoted only after its first durable `tool/call`. If the first model response was a plain-text reply (no tool call), the session stayed on the two-tool catalog **forever** — later requests could not see `grep`, `write`, `edit`, etc., and the model had no way to self-promote.

Now the session promotes after its first durable `tool/call` **or** its first `assistant/message`, whichever comes first:
- request #1 always sees the bootstrap catalog (the anchor effect is unchanged);
- request #2 always sees the full catalog — the "exactly two snapshots" property becomes a guarantee instead of luck;
- `promoteOn: tool-call` restores the original semantics, `assistant-message` is new.

### 2. Graceful degradation instead of throwing

A missing bootstrap tool (e.g. `tool-fs` removed, a shell tool renamed) previously threw from the assembly listener on every request, permanently bricking every session on the preset. It now emits a one-time warning and exposes the full catalog, so composition drift degrades instead of failing. Invalid `promoteOn` values still fail at preset mount, where they are visible and fixable.

### 3. Memoized promotion per session

Promotion decisions are cached per session id for the process lifetime; the durable event scan runs once per session per process, then O(1). Resume still derives the phase from durable events (correct across restarts).

## Verification

- `npm test`: 10/10 passing (new cases: first-reply promotion, per-session memoization, `tool-call`/`assistant-message` triggers, graceful degradation, invalid config rejection).
- The preset was installed locally and mount-validated via `agentPresets.standingKeyFor` on DeepSeek Harness `0.1.0-rc.6` (MOUNTED OK).
- The composition snapshot was diffed against the `standard` preset of the current rc.6 checkout: rows and configs are still in sync (no drift beyond the intended persona/tool-bootstrap differences).

## Notes

- The single-request cache-break note in the README is unchanged: the catalog still changes exactly once (between request #1 and request #2).
- No network requests or telemetry added, as before.