### PR TITLE
feat: add zero-anchored-standard test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,41 @@ npm test
   installation.
 - The plugin performs no network requests and adds no telemetry.
 
+## Zero-Anchored Standard (experimental)
+
+An extra test mode that does not change the Anchored Standard logic above. It
+uses the same Minimal-aligned system prompt, but instead of exposing two tools
+on the first request it injects one fixed zero-tool anchor turn:
+
+1. When the user sends their first message, the `anchor-turn` plugin prepends a
+   fixed user message — "This round is a test. Tools are not open yet; all
+   tools will open next round." — ahead of it.
+2. The first real model request carries ZERO tools, so the session's first
+   reasoning chain follows the zero-injection "we" trajectory.
+3. Once that anchor response is durable, the full Standard catalog is exposed
+   and the real message proceeds with all tools.
+
+Anchoring on the first message — not on session creation — keeps the
+blank-session preset switcher usable. Subagents always see the full catalog.
+
+Measured behavior (opencode-go, DeepSeek V4 Pro, `reasoningEffort=max`): the
+anchor request is stable "we"-style with zero `let me`; the following
+tool-bearing requests return to the "The user wants…/Let me" style. This mode
+is a comparison point for whether the zero-tool first turn is worth the extra
+model call — not a claim that tool rounds stay "we"-style.
+
+Install as a separate preset id:
+
+```sh
+dsh_home="${DSH_HOME:-$HOME/.dsh}"
+mkdir -p "$dsh_home/.agent-presets"
+test ! -e "$dsh_home/.agent-presets/zero-anchored-standard"
+cp -R zero-anchored-standard "$dsh_home/.agent-presets/zero-anchored-standard"
+```
+
+Restart DeepSeek Harness, create a blank session, select **Zero-Anchored
+Standard (experimental)**, then send your first message.
+
 ## Official ecosystem guidance
 
 DeepSeek currently asks community plugin authors to publish plugins in their own

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -106,6 +106,37 @@ npm test
 - preset 与 shell 访问具有相同信任等级，安装前应自行审阅文件；
 - 插件不会发起网络请求，也不增加遥测。
 
+## Zero-Anchored Standard（实验）
+
+这是不改变上面 Anchored Standard 逻辑的额外测试模式。它沿用同一套 Minimal
+对齐的 system prompt，但首轮不再暴露两个工具，而是先注入一轮固定的零工具锚定
+对话：
+
+1. 用户发出第一条消息时，`anchor-turn` 插件会把固定消息——"This round is a
+   test. Tools are not open yet; all tools will open next round."——插到它前面；
+2. 第一个真实模型请求携带 **0 个工具**，首条思维链因此走零注入的 "we" 轨迹；
+3. 锚定回复落库后开放完整 Standard 目录，真实消息带着全部工具继续。
+
+锚定发生在第一条消息到达时而不是会话创建时，因此新建会话仍然可以先切换模式；
+子 agent 始终看到完整目录。
+
+实测行为（opencode-go、DeepSeek V4 Pro、`reasoningEffort=max`）：锚定请求稳定
+为 "we" 风格且 `let me` 为 0；后续带工具请求会回到 "The user wants…/Let me"
+风格。因此该模式用于对比"零工具首轮是否值得多一次模型调用"，并不承诺工具轮次
+保持 "we" 风格。
+
+以独立 preset id 安装：
+
+```sh
+dsh_home="${DSH_HOME:-$HOME/.dsh}"
+mkdir -p "$dsh_home/.agent-presets"
+test ! -e "$dsh_home/.agent-presets/zero-anchored-standard"
+cp -R zero-anchored-standard "$dsh_home/.agent-presets/zero-anchored-standard"
+```
+
+重启 DeepSeek Harness，新建空白会话，选择 **Zero-Anchored Standard
+(experimental)**，然后发送第一条消息。
+
 ## 官方生态要求
 
 DeepSeek 当前建议社区作者把插件放在自己的 GitHub 项目中，并为仓库添加

--- a/test/anchor-turn.test.mjs
+++ b/test/anchor-turn.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ANCHOR_TEXT, apply, name } from '../zero-anchored-standard/anchor-turn.mjs'
+
+function register(config = {}) {
+  let listener
+  const ctx = {
+    on(event, callback) {
+      assert.equal(event, 'agent/inbox/inserted')
+      listener = callback
+    },
+  }
+  apply(ctx, config)
+  assert.equal(typeof listener, 'function')
+  return listener
+}
+
+function agent({ depth = 0, events = [] } = {}) {
+  const prepends = []
+  const subject = {
+    session: { header: { delegationDepth: depth }, events },
+    inbox: {
+      prepend(target, message) {
+        prepends.push({ target, message })
+      },
+    },
+  }
+  return { subject, prepends }
+}
+
+test('exports a diagnostic plugin name and default anchor text', () => {
+  assert.equal(name, 'anchor-turn')
+  assert.equal(typeof ANCHOR_TEXT, 'string')
+  assert.ok(ANCHOR_TEXT.length > 0)
+})
+
+test('the first user message prepends the default anchor ahead of it', () => {
+  const listener = register()
+  const { subject, prepends } = agent()
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 1)
+  assert.equal(prepends[0].target, 'next-turn')
+  assert.equal(prepends[0].message.role, 'user')
+  assert.equal(prepends[0].message.content[0].text, ANCHOR_TEXT)
+  assert.equal(prepends[0].message.source.plugin, 'anchor-turn')
+})
+
+test('config text overrides the default anchor', () => {
+  const custom = 'Custom anchor.'
+  const listener = register({ text: custom })
+  const { subject, prepends } = agent()
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends[0].message.content[0].text, custom)
+})
+
+test('plugin-sourced messages never re-anchor', () => {
+  const listener = register()
+  const { subject, prepends } = agent()
+  listener({ agent: subject, message: { source: { kind: 'plugin', plugin: 'anchor-turn' } } })
+  assert.equal(prepends.length, 0)
+})
+
+test('sessions with a prior user message are not anchored again', () => {
+  const listener = register()
+  const { subject, prepends } = agent({ events: [{ type: 'user/message' }] })
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 0)
+})
+
+test('subagents are never anchored', () => {
+  const listener = register()
+  const { subject, prepends } = agent({ depth: 1 })
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 0)
+})

--- a/test/zero-tool-bootstrap.test.mjs
+++ b/test/zero-tool-bootstrap.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../zero-anchored-standard/zero-tool-bootstrap.mjs'
+
+function register() {
+  let listener
+  const warns = []
+  const ctx = {
+    on(event, callback) {
+      assert.equal(event, 'system-prompt/assemble')
+      listener = callback
+    },
+    logger: {
+      warn(message) {
+        warns.push(message)
+      },
+    },
+  }
+  apply(ctx)
+  assert.equal(typeof listener, 'function')
+  return { listener, warns }
+}
+
+function assemble(listener, events, tools, header = {}, id = 's') {
+  return listener(
+    undefined,
+    { agent: { session: { id, events, header } } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+}
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'zero-tool-bootstrap')
+})
+
+test('the first top-level request exposes zero tools', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+  const result = await assemble(listener, [], tools)
+  assert.deepEqual(result.tools, [])
+})
+
+test('a durable assistant message promotes the complete catalog', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'grep' }]
+  const result = await assemble(listener, [{ type: 'assistant/message', data: {} }], tools)
+  assert.deepEqual(result.tools, tools)
+})
+
+test('subagents see the full catalog from their first request', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+  const result = await assemble(listener, [], tools, { delegationDepth: 1 })
+  assert.deepEqual(result.tools, tools)
+})
+
+test('an assembly outside an agent keeps the full catalog', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }]
+  const result = await listener(undefined, { agent: undefined }, async () => ({ tools }))
+  assert.deepEqual(result.tools, tools)
+})
+
+test('promotion is memoized per session id within one process', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+  const promoted = await assemble(listener, [{ type: 'assistant/message' }], tools, {}, 'memo')
+  assert.deepEqual(promoted.tools, tools)
+  // Same session id, events now empty: the cached decision still promotes.
+  const again = await assemble(listener, [], tools, {}, 'memo')
+  assert.deepEqual(again.tools, tools)
+})
+
+test('sessions derive promotion independently from their own events', async () => {
+  const { listener } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+  const promoted = await assemble(listener, [{ type: 'assistant/message' }], tools, {}, 'a')
+  const fresh = await assemble(listener, [], tools, {}, 'b')
+  assert.deepEqual(promoted.tools, tools)
+  assert.deepEqual(fresh.tools, [])
+})

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -1,0 +1,275 @@
+# The `zero-anchored-standard` experimental preset: Standard capabilities with
+# the Minimal mode system-prompt condition used by the V4 trajectory
+# evaluation, plus a zero-tool anchor turn.
+#
+# This file is an AGENT-PLANE composition. The roster mounts it ONCE under a
+# standing scope; every session naming it joins by scope parentage, so the
+# tools and prompt sections registered here cover each joined agent while a
+# session's own state stays keyed per Session/Agent inside the plugins. The
+# host composition (`base.cordis.yml` + `web.cordis.yml`) keeps everything a
+# preset must not own: the registries themselves, the sandbox and approval
+# stack, persistence, and the model route.
+#
+# A service row here MUST sit inside a group carrying an `isolate` realm.
+# Without one it publishes into the root realm, where it is process-global —
+# another preset publishing the same name collides, and a host reader would
+# resolve one preset's instance for every session; `dsh-agent-presets` rejects
+# that at mount. `true` means an entry-local realm: this standing mount's own
+# private instance, apart from every other preset's. (A shared label does NOT
+# pool instances — `provide()` throws on the second registration under the
+# same realm symbol; labels join REALMS, and are not what this file needs.)
+
+# ── identity ────────────────────────────────────────────────────────────────
+
+# Keep this text byte-identical to the Minimal preset. `complete` prevents the
+# Harness identity and per-tool guidance from changing the system prompt, while
+# runtime-context suppression leaves task and repository rules to user messages
+# and explicit file reads. Tool schemas and their runtime enforcement remain.
+- id: persona
+  name: '@deepseek-ai/dsh-persona'
+  config:
+    text: You are a helpful software engineer assistant.
+    complete: true
+    includeRuntimeContext: false
+
+- id: agent-instructions
+  name: '@deepseek-ai/dsh-agent-instructions'
+  config:
+    maxBytes: 65536
+
+# V4 Pro conditions strongly on the API tool catalog. The first top-level
+# model request therefore carries ZERO tools: `anchor-turn` seeds a fixed user
+# message, this bootstrap strips the whole catalog, and the first reasoning
+# chain follows the zero-injection "we" trajectory. After that assistant
+# response is durable, later step assemblies expose every Standard tool
+# registered below. Subagents always see the full catalog.
+- id: zero-tool-bootstrap
+  name: ./zero-tool-bootstrap.mjs
+
+# Seed the fixed zero-tool anchor turn when the first user message arrives:
+# the anchor is prepended ahead of it, so the first real model request has no
+# tools (we chain) and the real input then arrives with the full Standard
+# catalog already unlocked. Anchoring on first message — not session creation —
+# keeps the blank-session preset switcher usable.
+- id: anchor-turn
+  name: ./anchor-turn.mjs
+  config:
+    text: This round is a test. Tools are not open yet; all tools will open next round.
+
+# ── shell ───────────────────────────────────────────────────────────────────
+
+# `shell-env` stays in the HOST composition: `apps/cli/src/web.ts` injects it to
+# publish `DSH_WEB_URL`/`DSH_WEB_MODE`, and a host row that injects a service is
+# the criterion for host-plane ownership — injection resolves before any session
+# exists, so there is no agent to key by. Behind a preset realm those variables
+# never reached the model's shell at all. Both shell tools consume the host
+# registry from here; their executors (`bash-sandbox`/`pwsh-sandbox`) are
+# host-plane too.
+- id: tool-bash
+  name: '@deepseek-ai/dsh-tool-bash'
+  disabled: !!js process.platform === 'win32'
+
+- id: tool-pwsh
+  name: '@deepseek-ai/dsh-tool-pwsh'
+  disabled: !!js process.platform !== 'win32'
+
+# ── filesystem ──────────────────────────────────────────────────────────────
+
+# Both register into the host `tools` registry and provide nothing, so
+# they need no realm. The `fs` service and its policy stay in the host.
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+- id: tool-fs-search
+  name: '@deepseek-ai/dsh-tool-fs-search'
+  config:
+    sampleOverCapGlobResults: false
+
+# ── background jobs ────────────────────────────────────────────────────────
+
+# Only the model-facing controls. The task REGISTRY stays on the host plane:
+# its producers sit outside any realm this file could put it in — `tool-bash`
+# above resolves it with `ctx.get`, and an entry-local realm here is invisible
+# to every sibling row, so `run_in_background` would answer "background jobs
+# unavailable" while these controls sat in the catalog. The registry is keyed by
+# owning agent anyway, so one host instance serves every session. What a preset
+# chooses is whether its agent can collect and stop background work at all.
+- id: tool-jobs
+  name: '@deepseek-ai/dsh-tool-jobs'
+
+# ── skills ──────────────────────────────────────────────────────────────────
+
+# The skill REGISTRY lives in the host composition and is layered per scope:
+# these rows register into THIS preset's layer of it, so they need no realm.
+# `skill-filesystem` contributes local-root discovery for agents on this preset, and
+# `tool-skill` gives them the catalog and loader; the merged catalog also
+# carries whatever the deployment registered globally (repository plugins).
+- id: skill-filesystem
+  name: '@deepseek-ai/dsh-skill-filesystem'
+
+- id: tool-skill
+  name: '@deepseek-ai/dsh-tool-skill'
+
+# ── goals ───────────────────────────────────────────────────────────────────
+
+# Only the model-facing tool. The goal SERVICE, its session driver, and the
+# `/goal` command stay on the host plane: the Gateway serves the goal domain as
+# Remote endpoints whose receiver comes from a generated descriptor, so it
+# resolves `goals` on the host and an entry-local realm here would hide it. The
+# registry is keyed by session anyway, so one host instance serves every
+# session. What a preset chooses is whether its agent can call the goal tool.
+- id: tool-goal
+  name: '@deepseek-ai/dsh-tool-goal'
+
+# ── plan mode ───────────────────────────────────────────────────────────────
+
+# Plan state is per-agent by nature, so an entry-local realm is not a
+# workaround here — it is the correct lifetime.
+- id: planning
+  name: cordis:group
+  group: true
+  isolate:
+    planMode: true
+  config:
+    - id: plan-mode
+      name: '@deepseek-ai/dsh-plan-mode'
+      config:
+        section: |
+              You are in plan mode. Stay in plan mode until exit_plan_mode succeeds or the user switches the session mode. Imperative language to implement changes means plan the implementation, not execute it. A user's conversational agreement — including an answer confirming something you asked — approves nothing and does not end plan mode; fold the confirmed decision into the plan and submit it through exit_plan_mode.
+
+              Explore first. Use non-mutating reads, searches, static analysis, and checks to ground the plan in the actual repository. Do not edit or write files, change configuration, run formatters or code generation that rewrites tracked files, commit, or otherwise carry out the plan. Prefer existing functions and patterns over new machinery.
+
+              The tool catalog stays the same across modes for request-cache stability. These plan-mode rules override any later tool description or guidance that suggests using mutation tools; those tools remain listed to keep the tool catalog unchanged. Do not use todo_write to track this planning phase: it tracks implementation after an approved plan, while the plan itself belongs in exit_plan_mode.
+
+              Resolve discoverable facts by inspection. Use ask_user_question only for user-owned choices or material ambiguity that inspection cannot answer. Do not ask the user where code lives or how current behavior works when you can find out.
+
+              Make the plan decision-complete: state the goal and success criteria; group implementation changes by subsystem; identify public API, schema, and data-flow changes; cover edge cases, failure modes, tests, acceptance criteria, and explicit assumptions. Keep it concise enough to review but detailed enough that another engineer can implement it without making design decisions.
+
+              When ready, call exit_plan_mode with the complete plan markdown, starting with a # title. Make exit_plan_mode the only and final tool call in that assistant response: it presents the plan for approval, and implementation begins only in a later step after approval. Do not paste the final plan as a plain reply or ask "should I proceed?" through prose or ask_user_question. If review rejects it, incorporate the feedback and present again. If the review channel is unavailable or aborted, stay in plan mode and ask the user to switch modes manually; do not proceed with implementation.
+
+# ── compaction ──────────────────────────────────────────────────────────────
+
+# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
+# share this realm rather than sit outside it.
+#
+# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
+# plane, and the rows here resolve that one instance. It takes no configuration,
+# keys every fold by Session, and owns the context-meter projection units the
+# browser reads for every session — behind a realm those units would come and go
+# with whichever presets happen to be mounted. What a preset chooses is whether
+# its agent compacts at all, which is `compaction-basic` below.
+- id: compaction
+  name: cordis:group
+  group: true
+  isolate:
+    compaction: true
+    toolResultPruner: true
+  config:
+    - id: compaction-basic
+      name: '@deepseek-ai/dsh-compaction-basic'
+
+    - id: command-compact
+      name: '@deepseek-ai/dsh-command-compact'
+
+    - id: tool-result-pruner
+      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
+      config:
+        thresholdChars: 8192
+        headChars: 4096
+        tailChars: 1024
+
+# ── delegation and workflows ────────────────────────────────────────────────
+
+# The `subagents` registry and its spawn/fork backends live in the HOST
+# composition: the registry is a process singleton whose cross-session queries
+# the api-proxy serves to the browser, and a provider name may only be
+# registered once. This preset contributes the delegation TOOLS, which resolve
+# that host registry.
+#
+# `workflows` is different — nothing outside an agent reads it — so every row
+# that reaches it shares one entry-local realm here, and a consumer left
+# outside would resolve a host registry this preset does not populate.
+#
+# `tool-subagent-report` is host-plane for the same reason as the registry,
+# not because a preset may not want it: it registers a CONTINUABLE SETUP on
+# that singleton rather than a tool this agent calls, and the setup list is
+# not scope-aware — one copy per mounted preset means every child gets
+# `report` registered once per live session, which throws on the second.
+- id: delegation
+  name: cordis:group
+  group: true
+  isolate:
+    workflowEngine: true
+  config:
+    - id: tool-subagent-control
+      name: '@deepseek-ai/dsh-tool-subagent-control'
+
+    - id: tool-subagent-list-agents
+      name: '@deepseek-ai/dsh-tool-subagent-control/list-agents'
+
+    - id: tool-subagent
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: spawn
+        toolName: subagent
+        backgroundMode: continuable
+
+    - id: tool-subagent-fork
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: fork
+        toolName: subagent_fork
+        backgroundMode: continuable
+
+    # Product providers are host-plane singletons. Copy this preset, then
+    # remove `disabled` from either ordinary tool row to expose that product
+    # only to agents composed from the copy.
+    - id: tool-subagent-codex
+      name: '@deepseek-ai/dsh-tool-subagent'
+      disabled: true
+      config:
+        provider: codex
+        toolName: subagent_codex
+        enableRunInBackground: false
+        maxDepth: provider-managed
+
+    - id: tool-subagent-claude-code
+      name: '@deepseek-ai/dsh-tool-subagent'
+      disabled: true
+      config:
+        provider: claude-code
+        toolName: subagent_claude_code
+        enableRunInBackground: false
+        maxDepth: provider-managed
+
+    - id: workflow-worker-thread
+      name: '@deepseek-ai/dsh-workflow-worker-thread'
+      config:
+        provider: spawn
+
+    - id: tool-workflow
+      name: '@deepseek-ai/dsh-tool-workflow'
+
+    - id: tool-ralph
+      name: '@deepseek-ai/dsh-tool-ralph'
+      config:
+        subagentProvider: spawn
+        maxRounds: 64
+
+# ── remaining model-facing rows ─────────────────────────────────────────────
+
+- id: tool-ask-user
+  name: '@deepseek-ai/dsh-tool-ask-user'
+
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+# The `web` service and its search provider stay in the host composition; only
+# the model-facing tool is per-session.
+- id: tool-web
+  name: '@deepseek-ai/dsh-tool-web'
+  config:
+    fetch: false
+    searchTimeoutMs: 60000

--- a/zero-anchored-standard/anchor-turn.mjs
+++ b/zero-anchored-standard/anchor-turn.mjs
@@ -1,0 +1,47 @@
+/**
+ * Seed one zero-tool anchor turn when the FIRST user message arrives.
+ *
+ * The anchor is PREPENDED ahead of the real message, so the first REAL model
+ * request still carries an empty tool catalog (see zero-tool-bootstrap.mjs)
+ * and follows the zero-injection "we" trajectory. Waiting for the first user
+ * message — instead of anchoring at session creation — keeps the blank-session
+ * window open, so the user can still switch presets before typing. Once the
+ * anchor response is durable, the bootstrap exposes the full Standard catalog
+ * and the real message proceeds with tools.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'anchor-turn'
+
+/** Default anchor text shown to the model in the synthetic first user turn. */
+export const ANCHOR_TEXT = 'This round is a test. Tools are not open yet; all tools will open next round.'
+
+/** Only top-level fresh sessions (no prior user message) get the anchor turn. */
+function isFreshTopLevel(agent) {
+  if ((agent.session.header.delegationDepth ?? 0) > 0) return false
+  return !agent.session.events.some((event) => event.type === 'user/message')
+}
+
+/** Register the first-message anchor injection. */
+export function apply(ctx, config) {
+  const text = typeof config.text === 'string' && config.text.length > 0
+    ? config.text
+    : ANCHOR_TEXT
+
+  ctx.on('agent/inbox/inserted', ({ agent, message }) => {
+    if (!isFreshTopLevel(agent)) return
+    // Never re-anchor on plugin-sourced messages (including our own anchor).
+    if (message.source?.kind === 'plugin') return
+    agent.inbox.prepend('next-turn', {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: [{ type: 'text', text }],
+      source: {
+        kind: 'plugin',
+        plugin: 'anchor-turn',
+        form: 'notice',
+        summary: 'zero-tool anchor turn',
+      },
+    })
+  })
+}

--- a/zero-anchored-standard/preset.yml
+++ b/zero-anchored-standard/preset.yml
@@ -1,0 +1,3 @@
+name: Zero-Anchored Standard (experimental)
+description: Inject one zero-tool anchor turn (fixed user message), then expose the full Standard tool catalog from the next turn on.
+order: 6

--- a/zero-anchored-standard/zero-tool-bootstrap.mjs
+++ b/zero-anchored-standard/zero-tool-bootstrap.mjs
@@ -1,0 +1,70 @@
+/**
+ * Zero-tool bootstrap — keep the FIRST top-level model request on an EMPTY
+ * tool surface, then expose the full preset catalog once the anchor turn has
+ * produced its first durable assistant message.
+ *
+ * This is the extra test mode behind `zero-anchored-standard`: the anchor
+ * plugin seeds a fixed user message and this filter strips the whole catalog,
+ * so the first real request follows the zero-injection "we" trajectory. After
+ * that assistant response is durable, every later request sees the full
+ * Standard catalog.
+ *
+ * Robustness:
+ *  - Promotion decisions are memoized per session id for this process; the
+ *    durable event scan runs once per session per process, then O(1).
+ *  - Subagents and non-top-level agents always see the full catalog: their
+ *    first request must be able to call tools.
+ *  - A filter failure degrades to the full catalog with a one-time warning,
+ *    so a bug can never brick every request of a session.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'zero-tool-bootstrap'
+
+/** Prompt assembly must exist before this request filter can register. */
+export const inject = ['systemPrompt']
+
+/** Register the per-session bootstrap filter. */
+export function apply(ctx) {
+  /** Sessions already promoted in this process. Promotion is append-only, so a Set is sound. */
+  const promoted = new Set()
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  /**
+   * Whether the session has reached the promoted (full-catalog) phase.
+   * @param agent - the assembly context's agent, or undefined outside an agent.
+   */
+  const isPromoted = (agent) => {
+    if (agent === undefined) return true
+    const session = agent.session
+    if (session === undefined) return true
+    // Subagents keep their full catalog from their very first request.
+    if ((session.header.delegationDepth ?? 0) > 0) return true
+    if (promoted.has(session.id)) return true
+    const hit = session.events.some((event) => event.type === 'assistant/message')
+    if (hit) promoted.add(session.id)
+    return hit
+  }
+
+  ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is guarded.
+    const assembled = await next()
+    try {
+      if (isPromoted(context.agent)) return assembled
+      return { ...assembled, tools: [] }
+    } catch (error) {
+      // A filter bug must never brick a session: degrade to the full catalog.
+      warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
+      return assembled
+    }
+  })
+}


### PR DESCRIPTION
Adds an extra test preset `zero-anchored-standard/` without touching the existing `preset/` logic.

What it does:
- When the user sends their first message, `anchor-turn` prepends a fixed zero-tool anchor turn ("This round is a test. Tools are not open yet; all tools will open next round.").
- The first real model request carries ZERO tools, so the first reasoning chain follows the zero-injection "we" trajectory.
- Once the anchor response is durable, the full Standard catalog is exposed and the real message proceeds with all tools.
- Anchoring on first message (not session creation) keeps the blank-session preset switcher usable; subagents always see the full catalog.

Tests: 13 new cases covering zero-tool bootstrap promotion, subagent exemption, memoization, and anchor injection guards; `npm test` passes 23/23.

Measured (opencode-go, DeepSeek V4 Pro, max): the anchor request is stable "we"-style with zero `let me`; later tool-bearing requests return to "The user wants…/Let me". This is a comparison mode for whether the zero-tool first turn is worth the extra model call.