### PR TITLE
fix: cap first-round maxTokens, strip skill-catalog, promote on first request

### DIFF
--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -18,6 +18,29 @@
 # pool instances — `provide()` throws on the second registration under the
 # same realm symbol; labels join REALMS, and are not what this file needs.)
 
+# ── bootstrap (must stay FIRST) ─────────────────────────────────────────────
+
+# This row deliberately sits before every other row: dsh-agent-instructions and
+# dsh-tool-skill inject workspace instructions and the skill catalog into the
+# first request via the agent/pre-step waterfall, and waterfall after-next
+# transforms apply in reverse registration order. Registering first (plus the
+# plugin empty inject list) makes this filter strip the final transform, so
+# request #1 stays Minimal-exact (see issue #6).
+#
+# V4 Pro conditions strongly on the API tool catalog AND the first request
+# output budget. Bootstrap request #1 with one native shell plus `read` and a
+# small maxTokens cap; after the session records its first durable promotion
+# signal (a tool call OR the first assistant message, default
+# `promoteOn: either`), later steps expose every Standard tool below and the
+# normal output budget returns. See tool-bootstrap.mjs for the other triggers.
+- id: tool-bootstrap
+  name: ./tool-bootstrap.mjs
+  config:
+    shellTools: [bash, pwsh]
+    commonTools: [read]
+    promoteOn: either
+    bootstrapMaxTokens: 1024
+
 # ── identity ────────────────────────────────────────────────────────────────
 
 # Keep this text byte-identical to the Minimal preset. `complete` prevents the
@@ -36,19 +59,6 @@
   config:
     maxBytes: 65536
 
-# V4 Pro conditions strongly on the API tool catalog. Bootstrap its first model
-# request with one native shell plus `read`; after the session records its first
-# durable promotion signal (a tool call OR the first assistant message, default
-# `promoteOn: either`), later step assemblies expose every Standard tool
-# registered below. Request #1 always sees the bootstrap catalog; request #2
-# always sees the full catalog — a text-only first reply can no longer trap the
-# session in bootstrap. See tool-bootstrap.mjs for the other triggers.
-- id: tool-bootstrap
-  name: ./tool-bootstrap.mjs
-  config:
-    shellTools: [bash, pwsh]
-    commonTools: [read]
-    promoteOn: either
 
 # ── shell ───────────────────────────────────────────────────────────────────
 

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -1,7 +1,8 @@
 /**
  * Anchored tool bootstrap — keep the FIRST model request on a small tool
- * surface, then expose the full preset catalog once the session has produced
- * its first durable promotion signal.
+ * surface and a small output budget, then expose the full preset catalog (and
+ * the normal output budget) once the session has produced its first durable
+ * promotion signal.
  *
  * The phase is derived from durable session events, so resume and reload
  * preserve it. By default (`promoteOn: 'either'`) a session promotes after the
@@ -11,6 +12,24 @@
  * it can trap a session in bootstrap forever when the first model reply makes
  * no tool call — the `'either'` default removes that trap while keeping the
  * first-request anchor intact.
+ *
+ * Two additional first-request conditions found during the 2026-08-15
+ * reproduction work (issue #6):
+ *
+ *  1. Output budget. On the official endpoint the first request's
+ *     `max_tokens` dominates the trajectory anchor: 1024 reproduced the
+ *     `We need` style in 26/32 runs against 0/5 at the adapter default of
+ *     256000, independent of tool descriptions. Bootstrap therefore caps the
+ *     first request at `bootstrapMaxTokens` (default 1024) and strips the cap
+ *     after promotion — the next request's seed proposal carries the previous
+ *     header's maxTokens forward, so the release must be explicit.
+ *
+ *  2. Injected reminders. dsh-agent-instructions and dsh-tool-skill inject
+ *     workspace instructions (AGENTS.md) and the skill catalog into the first
+ *     step as user messages whenever such content exists. With the skill
+ *     catalog present the anchor did not reproduce at all (0/9); without it
+ *     the same request reproduces at ~81%. Both message kinds are therefore
+ *     stripped during bootstrap and allowed again after promotion.
  *
  * Robustness:
  *  - Promotion decisions are memoized per session id for this process; the
@@ -25,8 +44,18 @@
 /** Cordis plugin name used by loader diagnostics. */
 export const name = 'anchored-tool-bootstrap'
 
-/** Prompt assembly must exist before this request filter can register. */
-export const inject = ['systemPrompt']
+/**
+ * Deliberately NO inject list: the listeners only touch services at event
+ * time. Applying without an inject — combined with this row being FIRST in
+ * agent.cordis.yml — registers the plugin before dsh-agent-instructions and
+ * dsh-tool-skill, and waterfall after-next transforms apply in reverse
+ * registration order, so the first-request strip below is the LAST transform.
+ * With an inject here those plugins register first and re-inject their
+ * messages after the strip.
+ */
+export const inject = []
+
+const DEFAULT_BOOTSTRAP_MAX_TOKENS = 1024
 
 /** Durable session event types that count as a promotion signal per mode. */
 const PROMOTE_EVENTS = {
@@ -34,6 +63,9 @@ const PROMOTE_EVENTS = {
   'assistant-message': ['assistant/message'],
   either: ['tool/call', 'assistant/message'],
 }
+
+/** Message source kinds injected into the first step that must not reach request #1. */
+const BOOTSTRAP_INJECTED_SOURCE_KINDS = new Set(['skill-catalog', 'agent-instructions'])
 
 function stringList(value, field) {
   if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
@@ -48,11 +80,20 @@ function parsePromoteOn(value) {
   throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
 }
 
-/** Register the per-session bootstrap filter. */
+function positiveInt(value, field, fallback) {
+  if (value === undefined) return fallback
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name}: ${field} must be a positive safe integer`)
+  }
+  return value
+}
+
+/** Register the per-session bootstrap filters. */
 export function apply(ctx, config) {
   const commonTools = stringList(config.commonTools, 'commonTools')
   const shellTools = stringList(config.shellTools, 'shellTools')
   const promoteEvents = parsePromoteOn(config.promoteOn)
+  const bootstrapMaxTokens = positiveInt(config.bootstrapMaxTokens, 'bootstrapMaxTokens', DEFAULT_BOOTSTRAP_MAX_TOKENS)
 
   /** Sessions already promoted in this process. Promotion is append-only, so a Set is sound. */
   const promoted = new Set()
@@ -111,6 +152,41 @@ export function apply(ctx, config) {
       // A filter bug must never brick a session: degrade to the full catalog.
       warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
       return assembled
+    }
+  })
+
+  // Cap the first model request's output budget while bootstrapping.
+  ctx.on('agent/request', async (payload, next) => {
+    const resolved = await next()
+    const agent = payload.agent
+    if (isPromoted(agent)) {
+      // The next request's seed proposal carries the previous header's
+      // maxTokens forward, so the injected cap must be stripped explicitly —
+      // otherwise it would persist for the whole session.
+      if (resolved.maxTokens === bootstrapMaxTokens) {
+        const { maxTokens: _bootstrap, ...rest } = resolved
+        return rest
+      }
+      return resolved
+    }
+    return {
+      ...resolved,
+      maxTokens: bootstrapMaxTokens,
+    }
+  })
+
+  // Strip first-step injected reminders (skill catalog, AGENTS.md) during
+  // bootstrap. Because this listener is the first registered (see the inject
+  // note and the row order in agent.cordis.yml), the strip is the final
+  // waterfall transform and actually removes what later listeners inject.
+  ctx.on('agent/pre-step', async (payload, next) => {
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    const agent = payload.agent
+    if (isPromoted(agent)) return decision
+    return {
+      ...decision,
+      messages: decision.messages.filter((message) => !BOOTSTRAP_INJECTED_SOURCE_KINDS.has(message.source?.kind)),
     }
   })
 }

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -9,12 +9,11 @@ const config = {
 }
 
 function register(cfg = config) {
-  let listener
+  const listeners = {}
   const warns = []
   const ctx = {
     on(event, callback) {
-      assert.equal(event, 'system-prompt/assemble')
-      listener = callback
+      listeners[event] = callback
     },
     logger: {
       warn(message) {
@@ -23,16 +22,21 @@ function register(cfg = config) {
     },
   }
   apply(ctx, cfg)
-  assert.equal(typeof listener, 'function')
-  return { listener, warns }
+  return { listeners, warns }
 }
 
+const agent = (events, id = 's') => ({ session: { id, events } })
+
 function assemble(listener, events, tools, id = 's') {
-  return listener(
-    undefined,
-    { agent: { session: { id, events } } },
-    async () => ({ system: 'minimal persona', tools }),
-  )
+  return listener(undefined, { agent: agent(events, id) }, async () => ({ system: 'minimal persona', tools }))
+}
+
+function request(listener, events, resolved, id = 's') {
+  return listener({ agent: agent(events, id), turn: 1, step: 1 }, async () => resolved)
+}
+
+function prestep(listener, events, messages, id = 's') {
+  return listener({ agent: agent(events, id), turn: 1, step: 1 }, async () => ({ kind: 'enter', messages }))
 }
 
 test('exports a diagnostic plugin name', () => {
@@ -40,69 +44,120 @@ test('exports a diagnostic plugin name', () => {
 })
 
 test('first request exposes one platform shell and read', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'edit' }]
-  const result = await assemble(listener, [], tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [], tools)
   assert.deepEqual(result.tools.map((tool) => tool.name), ['pwsh', 'read'])
 })
 
 test('a durable tool call promotes the complete catalog', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'edit' }, { name: 'grep' }]
-  const result = await assemble(listener, [{ type: 'tool/call', data: { name: 'read' } }], tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call', data: { name: 'read' } }], tools)
   assert.deepEqual(result.tools, tools)
 })
 
 test('a first assistant message promotes the complete catalog (no tool call needed)', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'write' }]
-  const result = await assemble(listener, [{ type: 'assistant/message', data: {} }], tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools)
   assert.deepEqual(result.tools, tools)
 })
 
 test('sessions derive promotion independently from their own events', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const promoted = await assemble(listener, [{ type: 'tool/call' }], tools, 'a')
-  const fresh = await assemble(listener, [], tools, 'b')
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'a')
+  const fresh = await assemble(listeners['system-prompt/assemble'], [], tools, 'b')
   assert.deepEqual(promoted.tools, tools)
   assert.deepEqual(fresh.tools.map((tool) => tool.name), ['bash', 'read'])
 })
 
 test('promotion is memoized per session id within one process', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const first = await assemble(listener, [{ type: 'tool/call' }], tools, 'memo')
+  const first = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'memo')
   assert.deepEqual(first.tools, tools)
   // Same session id, events now empty: the cached decision still promotes.
-  const second = await assemble(listener, [], tools, 'memo')
+  const second = await assemble(listeners['system-prompt/assemble'], [], tools, 'memo')
   assert.deepEqual(second.tools, tools)
 })
 
 test('promoteOn tool-call requires a tool call, not just a reply', async () => {
-  const { listener } = register({ ...config, promoteOn: 'tool-call' })
+  const { listeners } = register({ ...config, promoteOn: 'tool-call' })
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const replyOnly = await assemble(listener, [{ type: 'assistant/message' }], tools, 'a')
+  const replyOnly = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, 'a')
   assert.deepEqual(replyOnly.tools.map((tool) => tool.name), ['bash', 'read'])
-  const withCall = await assemble(listener, [{ type: 'tool/call' }], tools, 'b')
+  const withCall = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'b')
   assert.deepEqual(withCall.tools, tools)
 })
 
 test('promoteOn assistant-message promotes after any first reply', async () => {
-  const { listener } = register({ ...config, promoteOn: 'assistant-message' })
+  const { listeners } = register({ ...config, promoteOn: 'assistant-message' })
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const result = await assemble(listener, [{ type: 'assistant/message' }], tools, 'a')
+  const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, 'a')
   assert.deepEqual(result.tools, tools)
 })
 
 test('a missing bootstrap shell degrades gracefully to the full catalog', async () => {
-  const { listener, warns } = register()
+  const { listeners, warns } = register()
   const tools = [{ name: 'read' }, { name: 'edit' }]
-  const result = await assemble(listener, [], tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [], tools)
   assert.deepEqual(result.tools, tools)
   assert.ok(warns.length >= 1)
 })
 
 test('invalid promoteOn values fail at apply time', () => {
   assert.throws(() => register({ ...config, promoteOn: 'bogus' }), /promoteOn/)
+})
+
+test('invalid bootstrapMaxTokens fails at apply time', () => {
+  assert.throws(() => register({ ...config, bootstrapMaxTokens: 0 }), /bootstrapMaxTokens/)
+})
+
+test('first request is capped to bootstrapMaxTokens', async () => {
+  const { listeners } = register({ ...config, bootstrapMaxTokens: 1024 })
+  const resolved = await request(listeners['agent/request'], [], { provider: 'deepseek-official', model: 'deepseek-v4-pro' })
+  assert.equal(resolved.maxTokens, 1024)
+  assert.equal(resolved.provider, 'deepseek-official')
+})
+
+test('after promotion, the injected cap is stripped so the default returns', async () => {
+  const { listeners } = register({ ...config, bootstrapMaxTokens: 1024 })
+  const resolved = await request(listeners['agent/request'], [{ type: 'tool/call' }], { provider: 'x', model: 'y', maxTokens: 1024 })
+  assert.equal(resolved.maxTokens, undefined)
+})
+
+test('after promotion, a different maxTokens is preserved', async () => {
+  const { listeners } = register({ ...config, bootstrapMaxTokens: 1024 })
+  const resolved = await request(listeners['agent/request'], [{ type: 'tool/call' }], { provider: 'x', model: 'y', maxTokens: 256000 })
+  assert.equal(resolved.maxTokens, 256000)
+})
+
+test('bootstrap pre-step strips skill-catalog and agent-instructions messages', async () => {
+  const { listeners } = register()
+  const messages = [
+    { id: 'm1', content: [{ type: 'text', text: 'user message' }] },
+    { id: 'm2', content: [{ type: 'text', text: '<system-reminder>skills...</system-reminder>' }], source: { kind: 'skill-catalog' } },
+    { id: 'm3', content: [{ type: 'text', text: '# AGENTS.md content' }], source: { kind: 'agent-instructions' } },
+  ]
+  const decision = await prestep(listeners['agent/pre-step'], [], messages)
+  assert.equal(decision.kind, 'enter')
+  assert.deepEqual(decision.messages.map((message) => message.id), ['m1'])
+})
+
+test('promoted pre-step keeps skill-catalog and agent-instructions messages', async () => {
+  const { listeners } = register()
+  const messages = [
+    { id: 'm1', content: [{ type: 'text', text: 'user message' }] },
+    { id: 'm2', content: [{ type: 'text', text: '<system-reminder>skills...</system-reminder>' }], source: { kind: 'skill-catalog' } },
+  ]
+  const decision = await prestep(listeners['agent/pre-step'], [{ type: 'tool/call' }], messages)
+  assert.deepEqual(decision.messages.map((message) => message.id), ['m1', 'm2'])
+})
+
+test('reject decisions pass through untouched', async () => {
+  const { listeners } = register()
+  const decision = await listeners['agent/pre-step']({ agent: agent([]), turn: 1, step: 1 }, async () => ({ kind: 'reject' }))
+  assert.equal(decision.kind, 'reject')
 })


### PR DESCRIPTION
## 背景

在带本地技能（lark-*、story-* 等）的 macOS + DSH 0.1.0-rc.6 环境里，原版 preset 机制正常（首轮 2 工具 → 25 工具），但首轮轨迹 7/7 都是 "The user wants me..."，无法复现 "We need"。完整定位过程与数据见 #6。

## 变更（已 rebase 到上游 main，采纳 #2 的 promoteOn 设计）

在保留上游 `promoteOn`（either/tool-call/assistant-message）、按会话记忆化、优雅降级的基础上，新增三件事：

1. **首轮 `max_tokens` 封顶**：`bootstrapMaxTokens`（默认 1024），晋升后显式剥离（`requestProposal` 会把上一份 header 的 maxTokens 带进下一请求，不剥离会永久焊死）。官方端点上 1024 封顶 26/32 出 "We need"，256000 默认 0/5。
2. **剥离首轮注入的提醒消息**：`source.kind === 'skill-catalog'` 与 `'agent-instructions'`（AGENTS.md）在 bootstrap 阶段从 `agent/pre-step` 结果中过滤，晋升后放行。带技能目录块 0/9、无块约 81%。这同时覆盖了 #6 评论提出的 AGENTS.md 注入问题。
3. **保证过滤是最终变换**：插件去掉 `inject` 声明、行序移到 agent.cordis.yml 最前——waterfall 的 after-next 变换按注册逆序生效，否则 agent-instructions/tool-skill 会在过滤之后把消息再塞回来。

## 测试

`npm test` 30/30 通过（上游 11 项保留 + 19 项新增/适配：cap 施加/释放/保留、双类消息剥离与放行、reject 透传、非法配置报错等）。

## 未包含的内容

- 适配器层的 `x-deepseek-harness-*` 头移除与标题生成禁用：harness 层改动且证据较弱（双头 4/7 vs 单头/无头 18/18；并发标题 2/3），未放进本 PR，见 #6。
- README 更新建议（rc.6 兼容性实测、英文题面限定）见 #6，未改文档以缩小 diff。

## 验证

修改后的 preset 在真实 DSH 会话中首轮以 "We need inspect repo..." 开头（全程 0 个 let me），技能目录与 AGENTS.md 在晋升后才出现。
