### PR TITLE
feat: make bootstrap context suppression configurable and degrade-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [中文说明](./README.zh-CN.md)
 
 An experimental DeepSeek Harness agent preset that bootstraps the first model
-request with a Minimal-aligned prompt and two tools, then exposes the complete
-Standard tool catalog after the first durable tool call.
+request with a Minimal-aligned prompt, two tools, and no auto-injected
+workspace/skill context, then exposes the complete Standard tool catalog after
+the first durable tool call or reply.
 
 This is a community project. It is not an official DeepSeek preset and is not
 affiliated with or endorsed by DeepSeek.
@@ -20,13 +21,18 @@ Anchored Standard separates initial trajectory selection from later tool use:
 
 1. Keep the Minimal complete system prompt.
 2. Expose only the platform shell plus `read` on the first model request.
-3. After the session records its first durable promotion signal — a `tool/call`
+3. Strip the auto-injected context on that first request as well — the
+   AGENTS.md/CLAUDE.md workspace digest and the available-skills reminder that
+   true Minimal never mounts (`suppressedContextSources` in the
+   `tool-bootstrap` row). User-initiated skill gestures are not filtered, and
+   both injections return unchanged from request #2 on.
+4. After the session records its first durable promotion signal — a `tool/call`
    or the first `assistant/message`, whichever comes first — expose all
    Standard tools. Request #1 always sees the bootstrap catalog; request #2
    always sees the full catalog, so a text-only first reply can no longer trap
    the session in bootstrap. (`promoteOn` in the `tool-bootstrap` row selects
    the trigger: `either` default, `tool-call`, or `assistant-message`.)
-4. Derive the phase from durable session events so resume and reload preserve it.
+5. Derive the phase from durable session events so resume and reload preserve it.
 
 On Windows the bootstrap catalog is `pwsh/read`; on Linux it is `bash/read`.
 
@@ -90,9 +96,13 @@ different preset.
 Export the session JSONL and inspect `request/header` events:
 
 - the first header should contain only `pwsh/read` or `bash/read`;
+- the first request's messages should contain no AGENTS.md/CLAUDE.md digest and
+  no available-skills reminder — only the user message and the minimal persona
+  system prompt;
 - after the first tool call or the first assistant reply, the next changed
   header should contain the full Standard catalog;
-- subsequent requests should keep that full catalog.
+- subsequent requests should keep that full catalog and restore the standard
+  context injections.
 
 Run the local zero-dependency tests with:
 
@@ -115,6 +125,12 @@ npm test
   session; invalid `promoteOn` values fail at preset mount instead.
 - Promotion decisions are memoized per session for the process lifetime; the
   durable event scan runs once per session per process.
+- While a session is unpromoted, the pre-step filter strips messages whose
+  `source.kind` is listed in `suppressedContextSources` (default:
+  `agent-instructions` and `skill-catalog`, the two automatic injections
+  Standard adds over Minimal). Set the list to `[]` to disable the context
+  filter; add other `source.kind` values to suppress more. A filter failure
+  degrades to keeping every message rather than eating context.
 - The tool catalog changes once, so request-prefix cache continuity also changes
   once between the first and second model requests.
 - The preset has the same trust level as shell access. Review its files before

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,8 +3,9 @@
 [English](./README.md)
 
 这是一个实验性的 DeepSeek Harness agent preset：第一次模型请求使用与 Minimal 对齐的
-完整 system prompt 和两项工具；会话记录首次持久晋升信号（`tool/call` 或首次
-`assistant/message`，先到者为准）后，开放 Standard 的完整工具目录。
+完整 system prompt、两项工具，并且不注入工作区/技能上下文；会话记录首次持久晋升信号
+（`tool/call` 或首次 `assistant/message`，先到者为准）后，开放 Standard 的完整工具目录
+并恢复常规上下文注入。
 
 这是社区项目，并非 DeepSeek 官方 preset，也不代表 DeepSeek 的认可或背书。
 
@@ -18,11 +19,15 @@ Anchored Standard 把“首次轨迹选择”和“后续完整工具能力”�
 
 1. 保持 Minimal 的完整 system prompt；
 2. 首次模型请求只暴露当前平台 shell 和 `read`；
-3. 会话出现首次持久晋升信号（`tool/call` 或首次 `assistant/message`，先到者为准）
+3. 首次请求同时剥离自动注入的上下文——AGENTS.md/CLAUDE.md 工作区摘要和可用技能
+   目录提醒，真正的 Minimal 根本不挂载这两个插件（`tool-bootstrap` 行的
+   `suppressedContextSources`）。用户主动的技能手势不被过滤，且两者从请求 #2 起
+   原样恢复；
+4. 会话出现首次持久晋升信号（`tool/call` 或首次 `assistant/message`，先到者为准）
    后开放全部 Standard 工具——请求 #1 恒为 bootstrap 目录，请求 #2 起恒为完整目录，
    纯文字首答不再把会话困死在 bootstrap（`tool-bootstrap` 行的 `promoteOn` 可选
    `either` 默认 / `tool-call` / `assistant-message`）；
-4. 从持久 session event 推导阶段，resume 和 reload 不会丢失状态。
+5. 从持久 session event 推导阶段，resume 和 reload 不会丢失状态。
 
 Windows 首次目录为 `pwsh/read`，Linux 为 `bash/read`。
 
@@ -83,8 +88,10 @@ cp -R preset "$dsh_home/.agent-presets/anchored-standard"
 导出 session JSONL，检查 `request/header`：
 
 - 第一份 header 应只有 `pwsh/read` 或 `bash/read`；
+- 第一次请求的消息中不应包含 AGENTS.md/CLAUDE.md 摘要或可用技能目录提醒——只有
+  用户消息与 Minimal persona 系统提示；
 - 首次工具调用或首次助手回复后，下一份变更 header 应包含完整 Standard 目录；
-- 此后的请求应保持完整目录。
+- 此后的请求应保持完整目录，并恢复常规上下文注入。
 
 本仓库的零依赖测试：
 
@@ -102,6 +109,10 @@ npm test
 - bootstrap 工具缺失时降级为完整目录并一次性告警，不再让请求失败，组合漂移不会锁死
   会话；非法的 `promoteOn` 值会在 preset 挂载时报错；
 - 晋升判定按会话在进程内记忆化，持久事件扫描每会话每进程只执行一次。
+- 会话未晋升期间，pre-step 过滤器剥离 `source.kind` 列在 `suppressedContextSources`
+  中的消息（默认 `agent-instructions` 与 `skill-catalog`，即 Standard 比 Minimal 多出的
+  两项自动注入）。设为 `[]` 可关闭上下文过滤；加入其他 `source.kind` 可抑制更多。
+  过滤器自身出错时降级为保留全部消息，绝不吞掉上下文。
 - 工具目录只变化一次，因此第一、第二次请求之间也会发生一次前缀缓存变化；
 - preset 与 shell 访问具有相同信任等级，安装前应自行审阅文件；
 - 插件不会发起网络请求，也不增加遥测。

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -31,6 +31,11 @@
     complete: true
     includeRuntimeContext: false
 
+# Mounted for the PROMOTED phase: its `agent/pre-step` workspace-context
+# injection (AGENTS.md / CLAUDE.md digests) is stripped from request #1 by
+# tool-bootstrap below, because true Minimal mounts no instruction loader at
+# all. Same reasoning as the persona: the first request must approximate
+# Minimal, not just on the tool catalog but on injected context.
 - id: agent-instructions
   name: '@deepseek-ai/dsh-agent-instructions'
   config:
@@ -43,12 +48,22 @@
 # registered below. Request #1 always sees the bootstrap catalog; request #2
 # always sees the full catalog — a text-only first reply can no longer trap the
 # session in bootstrap. See tool-bootstrap.mjs for the other triggers.
+#
+# The same phase gate also suppresses AUTO-INJECTED context on request #1:
+# `suppressedContextSources` lists the `agent/pre-step` message sources the
+# bootstrap filter strips while the session is unpromoted. The defaults are the
+# two automatic injections Standard adds over Minimal — the workspace
+# instruction digest (`agent-instructions`) and the available-skills reminder
+# (`skill-catalog`). User-initiated skill gestures are not filtered, and both
+# injections return unchanged from request #2 on. Set the list to [] to keep
+# the original context behavior.
 - id: tool-bootstrap
   name: ./tool-bootstrap.mjs
   config:
     shellTools: [bash, pwsh]
     commonTools: [read]
     promoteOn: either
+    suppressedContextSources: [agent-instructions, skill-catalog]
 
 # ── shell ───────────────────────────────────────────────────────────────────
 

--- a/preset/preset.yml
+++ b/preset/preset.yml
@@ -1,3 +1,3 @@
 name: Anchored Standard (experimental)
-description: Bootstrap with shell/read, then expose the full Standard tool catalog after the first durable tool call or reply.
+description: Bootstrap with shell/read and no auto-injected workspace or skill context, then expose the full Standard catalog after the first durable tool call or reply.
 order: 5

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -1,7 +1,8 @@
 /**
  * Anchored tool bootstrap — keep the FIRST model request on a small tool
- * surface, then expose the full preset catalog once the session has produced
- * its first durable promotion signal.
+ * surface AND free of auto-injected workspace/skill context, then expose the
+ * full preset catalog and restore standard context injection once the session
+ * has produced its first durable promotion signal.
  *
  * The phase is derived from durable session events, so resume and reload
  * preserve it. By default (`promoteOn: 'either'`) a session promotes after the
@@ -12,14 +13,27 @@
  * no tool call — the `'either'` default removes that trap while keeping the
  * first-request anchor intact.
  *
+ * True Minimal mounts neither `agent-instructions` nor the skill machinery, so
+ * its first request carries no AGENTS.md/CLAUDE.md digest and no skill-catalog
+ * reminder. Those rows stay mounted here for the promoted phase, but during
+ * bootstrap their `agent/pre-step` message injections are stripped (default
+ * `suppressedContextSources: ['agent-instructions', 'skill-catalog']`), so the
+ * first request approximates Minimal on the prompt side as well as the tool
+ * side. A user-initiated skill gesture (`skill-invocation`) is NOT suppressed:
+ * it is not an automatic injection, and stripping it would lose the skill
+ * content once the gesture scrolls out of the per-step claim.
+ *
  * Robustness:
  *  - Promotion decisions are memoized per session id for this process; the
  *    durable event scan runs once per session per process, then O(1).
  *  - A missing bootstrap tool degrades to the full catalog with a one-time
  *    warning instead of throwing, so a composition drift can never brick
  *    every request of a session.
- *  - Invalid config (bad tool lists, unknown `promoteOn`) fails at apply
- *    time, i.e. at preset mount, where it is visible and fixable.
+ *  - The pre-step context filter degrades to "keep everything" on failure:
+ *    a filter bug must never eat the user's context.
+ *  - Invalid config (bad tool lists, unknown `promoteOn`, malformed
+ *    `suppressedContextSources`) fails at apply time, i.e. at preset mount,
+ *    where it is visible and fixable.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -35,6 +49,14 @@ const PROMOTE_EVENTS = {
   either: ['tool/call', 'assistant/message'],
 }
 
+/**
+ * Context sources stripped from the first request by default. Both are
+ * automatic `agent/pre-step` injections: the AGENTS.md/CLAUDE.md workspace
+ * digest (`agent-instructions`) and the available-skills reminder
+ * (`skill-catalog`). True Minimal mounts neither plugin.
+ */
+const DEFAULT_SUPPRESSED_SOURCES = ['agent-instructions', 'skill-catalog']
+
 function stringList(value, field) {
   if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
     throw new TypeError(`${name}: ${field} must be a non-empty array of non-empty strings`)
@@ -48,11 +70,25 @@ function parsePromoteOn(value) {
   throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
 }
 
+/**
+ * Validate the suppressed context sources. Unlike the bootstrap tool lists,
+ * an explicitly empty array is meaningful: it disables the context filter
+ * while keeping the tool bootstrap.
+ */
+function sourceList(value, field, fallback) {
+  if (value === undefined) return new Set(fallback)
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be an array of non-empty strings`)
+  }
+  return new Set(value)
+}
+
 /** Register the per-session bootstrap filter. */
 export function apply(ctx, config) {
   const commonTools = stringList(config.commonTools, 'commonTools')
   const shellTools = stringList(config.shellTools, 'shellTools')
   const promoteEvents = parsePromoteOn(config.promoteOn)
+  const suppressedSources = sourceList(config.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
 
   /** Sessions already promoted in this process. Promotion is append-only, so a Set is sound. */
   const promoted = new Set()
@@ -113,4 +149,23 @@ export function apply(ctx, config) {
       return assembled
     }
   })
+
+  ctx.on('agent/pre-step', async ({ agent }, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is guarded.
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    try {
+      if (isPromoted(agent) || suppressedSources.size === 0) return decision
+      if (!Array.isArray(decision.messages)) return decision
+      const kept = decision.messages.filter((message) => {
+        const kind = message?.source?.kind
+        return typeof kind !== 'string' || !suppressedSources.has(kind)
+      })
+      return kept.length === decision.messages.length ? decision : { ...decision, messages: kept }
+    } catch (error) {
+      // A filter bug must never eat context: degrade to keeping every message.
+      warnOnce(`${name}: pre-step context filter failed, keeping injected context: ${String((error && error.message) || error)}`)
+      return decision
+    }
+  }, { prepend: true })
 }

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -9,12 +9,11 @@ const config = {
 }
 
 function register(cfg = config) {
-  let listener
+  const listeners = new Map()
   const warns = []
   const ctx = {
-    on(event, callback) {
-      assert.equal(event, 'system-prompt/assemble')
-      listener = callback
+    on(event, callback, options) {
+      listeners.set(event, { callback, options })
     },
     logger: {
       warn(message) {
@@ -23,86 +22,161 @@ function register(cfg = config) {
     },
   }
   apply(ctx, cfg)
-  assert.equal(typeof listener, 'function')
-  return { listener, warns }
+  assert.equal(typeof listeners.get('system-prompt/assemble')?.callback, 'function')
+  assert.equal(typeof listeners.get('agent/pre-step')?.callback, 'function')
+  return { listeners, warns }
 }
 
-function assemble(listener, events, tools, id = 's') {
-  return listener(
+function assemble(listeners, events, tools, id = 's') {
+  return listeners.get('system-prompt/assemble').callback(
     undefined,
     { agent: { session: { id, events } } },
     async () => ({ system: 'minimal persona', tools }),
   )
 }
 
+function preStep(listeners, events, messages, id = 's') {
+  return listeners.get('agent/pre-step').callback(
+    { agent: { session: { id, events } } },
+    async () => ({ kind: 'enter', messages }),
+  )
+}
+
+const userMessage = { id: 'u', content: [{ type: 'text', text: 'hi' }], source: { kind: 'user' } }
+const instructionMessage = { id: 'i', content: [], source: { kind: 'agent-instructions' } }
+const catalogMessage = { id: 'c', content: [], source: { kind: 'skill-catalog' } }
+const gestureMessage = { id: 'g', content: [], source: { kind: 'skill-invocation' } }
+const pluginMessage = { id: 'p', content: [], source: { kind: 'plugin' } }
+
 test('exports a diagnostic plugin name', () => {
   assert.equal(name, 'anchored-tool-bootstrap')
 })
 
 test('first request exposes one platform shell and read', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'edit' }]
-  const result = await assemble(listener, [], tools)
+  const result = await assemble(listeners, [], tools)
   assert.deepEqual(result.tools.map((tool) => tool.name), ['pwsh', 'read'])
 })
 
 test('a durable tool call promotes the complete catalog', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'edit' }, { name: 'grep' }]
-  const result = await assemble(listener, [{ type: 'tool/call', data: { name: 'read' } }], tools)
+  const result = await assemble(listeners, [{ type: 'tool/call', data: { name: 'read' } }], tools)
   assert.deepEqual(result.tools, tools)
 })
 
 test('a first assistant message promotes the complete catalog (no tool call needed)', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'pwsh' }, { name: 'read' }, { name: 'write' }]
-  const result = await assemble(listener, [{ type: 'assistant/message', data: {} }], tools)
+  const result = await assemble(listeners, [{ type: 'assistant/message', data: {} }], tools)
   assert.deepEqual(result.tools, tools)
 })
 
 test('sessions derive promotion independently from their own events', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const promoted = await assemble(listener, [{ type: 'tool/call' }], tools, 'a')
-  const fresh = await assemble(listener, [], tools, 'b')
+  const promoted = await assemble(listeners, [{ type: 'tool/call' }], tools, 'a')
+  const fresh = await assemble(listeners, [], tools, 'b')
   assert.deepEqual(promoted.tools, tools)
   assert.deepEqual(fresh.tools.map((tool) => tool.name), ['bash', 'read'])
 })
 
 test('promotion is memoized per session id within one process', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const first = await assemble(listener, [{ type: 'tool/call' }], tools, 'memo')
+  const first = await assemble(listeners, [{ type: 'tool/call' }], tools, 'memo')
   assert.deepEqual(first.tools, tools)
   // Same session id, events now empty: the cached decision still promotes.
-  const second = await assemble(listener, [], tools, 'memo')
+  const second = await assemble(listeners, [], tools, 'memo')
   assert.deepEqual(second.tools, tools)
 })
 
 test('promoteOn tool-call requires a tool call, not just a reply', async () => {
-  const { listener } = register({ ...config, promoteOn: 'tool-call' })
+  const { listeners } = register({ ...config, promoteOn: 'tool-call' })
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const replyOnly = await assemble(listener, [{ type: 'assistant/message' }], tools, 'a')
+  const replyOnly = await assemble(listeners, [{ type: 'assistant/message' }], tools, 'a')
   assert.deepEqual(replyOnly.tools.map((tool) => tool.name), ['bash', 'read'])
-  const withCall = await assemble(listener, [{ type: 'tool/call' }], tools, 'b')
+  const withCall = await assemble(listeners, [{ type: 'tool/call' }], tools, 'b')
   assert.deepEqual(withCall.tools, tools)
 })
 
 test('promoteOn assistant-message promotes after any first reply', async () => {
-  const { listener } = register({ ...config, promoteOn: 'assistant-message' })
+  const { listeners } = register({ ...config, promoteOn: 'assistant-message' })
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const result = await assemble(listener, [{ type: 'assistant/message' }], tools, 'a')
+  const result = await assemble(listeners, [{ type: 'assistant/message' }], tools, 'a')
   assert.deepEqual(result.tools, tools)
 })
 
 test('a missing bootstrap shell degrades gracefully to the full catalog', async () => {
-  const { listener, warns } = register()
+  const { listeners, warns } = register()
   const tools = [{ name: 'read' }, { name: 'edit' }]
-  const result = await assemble(listener, [], tools)
+  const result = await assemble(listeners, [], tools)
   assert.deepEqual(result.tools, tools)
   assert.ok(warns.length >= 1)
 })
 
 test('invalid promoteOn values fail at apply time', () => {
   assert.throws(() => register({ ...config, promoteOn: 'bogus' }), /promoteOn/)
+})
+
+test('pre-step filter registers before every other listener', () => {
+  const { listeners } = register()
+  assert.equal(listeners.get('agent/pre-step').options?.prepend, true)
+})
+
+test('bootstrap strips auto-injected workspace and skill context', async () => {
+  const { listeners } = register()
+  const decision = await preStep(listeners, [], [
+    userMessage,
+    instructionMessage,
+    catalogMessage,
+    gestureMessage,
+    pluginMessage,
+  ])
+  assert.equal(decision.kind, 'enter')
+  assert.deepEqual(decision.messages.map((message) => message.id), ['u', 'g', 'p'])
+})
+
+test('a promoted session keeps every injected context message', async () => {
+  const { listeners } = register()
+  const messages = [userMessage, instructionMessage, catalogMessage, pluginMessage]
+  const decision = await preStep(listeners, [{ type: 'tool/call' }], messages)
+  assert.equal(decision.messages, messages)
+})
+
+test('a text-only first reply promotes the context injections too', async () => {
+  const { listeners } = register()
+  const stripped = await preStep(listeners, [], [userMessage, instructionMessage, catalogMessage])
+  assert.deepEqual(stripped.messages.map((message) => message.id), ['u'])
+  const kept = await preStep(listeners, [{ type: 'assistant/message' }], [userMessage, instructionMessage])
+  assert.deepEqual(kept.messages.map((message) => message.id), ['u', 'i'])
+})
+
+test('rejected decisions pass through the context filter untouched', async () => {
+  const { listeners } = register()
+  const decision = { kind: 'reject', messages: [userMessage, instructionMessage] }
+  const result = await listeners.get('agent/pre-step').callback(
+    { agent: { session: { id: 's', events: [] } } },
+    async () => decision,
+  )
+  assert.equal(result, decision)
+})
+
+test('suppressedContextSources is configurable', async () => {
+  const { listeners } = register({ ...config, suppressedContextSources: ['skill-invocation'] })
+  const decision = await preStep(listeners, [], [userMessage, instructionMessage, catalogMessage, gestureMessage])
+  assert.deepEqual(decision.messages.map((message) => message.id), ['u', 'i', 'c'])
+})
+
+test('an empty suppressedContextSources disables the context filter', async () => {
+  const { listeners } = register({ ...config, suppressedContextSources: [] })
+  const messages = [userMessage, instructionMessage, catalogMessage]
+  const decision = await preStep(listeners, [], messages)
+  assert.equal(decision.messages, messages)
+})
+
+test('invalid suppressedContextSources values fail at apply time', () => {
+  assert.throws(() => register({ ...config, suppressedContextSources: 'agent-instructions' }), /suppressedContextSources/)
+  assert.throws(() => register({ ...config, suppressedContextSources: ['agent-instructions', 42] }), /suppressedContextSources/)
 })


### PR DESCRIPTION
## 与 PR #7 的关系

main 上的 PR #7 已经实现了 bootstrap 期剥离 skill-catalog / agent-instructions 与首轮 `maxTokens` 上限（这正是本 PR 最初要实现的核心）。合并 main 后，本 PR 保留的增量是：

## 本 PR 的增量

- **可配置的过滤集合**：新增 `suppressedContextSources`（默认 `['agent-instructions', 'skill-catalog']`，与 PR #7 硬编码的集合一致）；设为 `[]` 可关闭上下文过滤（工具引导与输出上限不受影响）；也可以加入其他 `source.kind` 抑制更多注入。
- **降级安全**：pre-step 过滤器用 try/catch 包裹，出错时保留全部消息并告警一次，过滤器缺陷不会吞掉用户上下文（工具过滤已有同样的降级策略）。
- **最外层保证**：`agent/pre-step` 监听器以 `{ prepend: true }` 注册，配合行首位置与空 inject，确保剥离发生在瀑布流的最后变换，且对未来的行序调整免疫。
- **文档与测试**：README（中英文）、`preset.yml` 描述、`agent.cordis.yml` 注释同步更新；tool-bootstrap 测试增至 23 个（可配置、禁用、降级、用户技能手势保留、prepend 注册等），全部通过。

## 验证

- 仓库全部测试 36/36 通过（tool-bootstrap 23 + anchor-turn 6 + zero-tool-bootstrap 7）。
- 组合文件经 DSH `scanRoot` 健康检查通过（`preset` 与 `zero-anchored-standard` 均 OK）。
- fork 侧 `test` workflow 在每次 push 均通过（含最新合并提交，3/3 green）。PR 侧的 `pull_request` 检查未自动注册（fork 的 Actions 初始为暂停状态，已通过 API 启用），如需要可手动触发。

## 冲突解决

已合并 main（`80e888d`）到分支：完整保留 PR #7 的行为（含 `bootstrapMaxTokens` 上限），本 PR 仅叠加可配置性与健壮性。分支现为 MERGEABLE。

## 备注

- 两个 `chore: retrigger CI` 空提交是排查 CI 触发时的尝试，合并时建议 squash。