### PR TITLE
fix: register the first-round budget cap with prepend

### DIFF
--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -188,6 +188,11 @@ export function apply(ctx, config) {
   })
 
   // Cap the first model request's output budget while bootstrapping.
+  // prepend:true keeps this listener the OUTERMOST transform of the
+  // agent/request waterfall for the same registration-order reasons as the
+  // pre-step strip below (loader row application is concurrent; row order
+  // alone does not decide listener order — see issue #6), so a later
+  // listener can never override the first-round budget after we set it.
   ctx.on('agent/request', async (payload, next) => {
     const resolved = await next()
     const agent = payload.agent
@@ -205,7 +210,7 @@ export function apply(ctx, config) {
       ...resolved,
       maxTokens: bootstrapMaxTokens,
     }
-  })
+  }, { prepend: true })
 
   // Strip first-step injected reminders (skill catalog, AGENTS.md) during
   // bootstrap. Because this listener is the first registered (see the inject

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -214,3 +214,9 @@ test('invalid suppressedContextSources values fail at apply time', () => {
   assert.throws(() => register({ ...config, suppressedContextSources: 'agent-instructions' }), /suppressedContextSources/)
   assert.throws(() => register({ ...config, suppressedContextSources: ['agent-instructions', 42] }), /suppressedContextSources/)
 })
+
+test('the pre-step strip and the budget cap both register with prepend', () => {
+  const { hookOptions } = register()
+  assert.deepEqual(hookOptions['agent/pre-step'], { prepend: true })
+  assert.deepEqual(hookOptions['agent/request'], { prepend: true })
+})


### PR DESCRIPTION
与 pre-step 剥离相同的注册顺序问题（issue #6 的并发 loader 分析）：agent/request 的封顶监听器也必须用 { prepend: true } 注册，确保它是该瀑布的最外层变换，避免后续注册的监听器覆盖首轮预算。顺带在单测里断言两个监听器的 prepend 选项。npm test 37/37。