### PR TITLE
feat: Windows bash support via custom-bash (PTY-free Minimal schema)

### DIFF
--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -34,8 +34,8 @@
 # 5/5 anchored vs 11/11 standard-like for every standard-family schema);
 # after the session records its first durable promotion signal (a tool call OR
 # the first assistant message, default `promoteOn: either`), later steps
-# expose every Standard tool below. `bootstrapMaxTokens` is opt-in for
-# standard-schema bootstraps; unset, the adapter default flows. See
+# narrow to the minimal RESIDENT set (see below). `bootstrapMaxTokens` is
+# opt-in for standard-schema bootstraps; unset, the adapter default flows. See
 # tool-bootstrap.mjs for the other triggers.
 #
 # The same phase gate suppresses AUTO-INJECTED context on request #1:
@@ -46,12 +46,26 @@
 # (`agent-instructions`). User-initiated skill gestures are not filtered, and
 # both injections return unchanged from request #2 on. Set the list to [] to
 # disable the context filter while keeping the tool bootstrap.
+#
+# POST-PROMOTION (local addition): the promoted catalog is NOT the full
+# Standard dump — it stays on the bootstrap pair + the three discovery tools
+# (dev_tool_search / skill_search / skill_load) + whatever the model unlocked
+# via dev_tool_search. Heavier tools are one dev_tool_search away; the
+# trajectory is not pulled back to standard-like behavior by a 25-tool dump.
+#
+# COMPACTION (local addition): after `compaction/end` the session falls back
+# to the controlled phase — bootstrap pair + `compactionTools` — until a NEW
+# durable promotion signal exists past the boundary (epoch-aware, see
+# compaction-epoch.mjs).
 - id: tool-bootstrap
   name: ./tool-bootstrap.mjs
   config:
     bootstrapTools: [bash, str_replace_editor]
     promoteOn: either
     suppressedContextSources: [agent-instructions, skill-catalog]
+    # Post-compaction core work set: the model is mid-task and needs to keep
+    # working, but faces a small catalog instead of the full Standard set.
+    compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
 
 # ── identity ────────────────────────────────────────────────────────────────
 
@@ -66,15 +80,23 @@
     complete: true
     includeRuntimeContext: false
 
-# Mounted for the PROMOTED phase: its `agent/pre-step` workspace-context
-# injection (AGENTS.md / CLAUDE.md digests) is stripped from request #1 by the
-# tool-bootstrap row above, because true Minimal mounts no instruction loader at
-# all. Same reasoning as the persona: the first request must approximate
-# Minimal, not just on the tool catalog but on injected context.
-- id: agent-instructions
-  name: '@deepseek-ai/dsh-agent-instructions'
+# Instruction FILES are NOT injected (replaces dsh-agent-instructions, local
+# addition): the full AGENTS.md/CLAUDE.md digest is a large injected block
+# that perturbs the trajectory even after promotion. Instead, after promotion
+# ONE short hint is injected once per session — "these instruction files
+# exist; read them before acting" — and the model reads the files itself via
+# the filesystem tools when relevant.
+- id: instruction-hint
+  name: ./instruction-hint.mjs
   config:
-    maxBytes: 65536
+    promoteOn: either
+
+# On-demand tool discovery (the tool-search pattern, local addition): the
+# promoted catalog keeps a minimal resident set; heavier Standard tools
+# (web_search, subagent, workflow, …) are unlocked on demand via
+# dev_tool_search.
+- id: dev-tool-search
+  name: ./dev-tool-search.mjs
 
 # ── shell ───────────────────────────────────────────────────────────────────
 
@@ -182,14 +204,18 @@
 
 # The skill REGISTRY lives in the host composition and is layered per scope:
 # these rows register into THIS preset's layer of it, so they need no realm.
-# `skill-filesystem` contributes local-root discovery for agents on this preset, and
-# `tool-skill` gives them the catalog and loader; the merged catalog also
-# carries whatever the deployment registered globally (repository plugins).
+# `skill-filesystem` contributes local-root discovery for agents on this
+# preset. The full skill CATALOG injection (`dsh-tool-skill`, the ~9KB
+# `<available_skills>` reminder) is REMOVED (local addition): it perturbs the
+# trajectory (issue #6: 0/9 anchored with the catalog present vs ~81%
+# without). Instead `skill-search` exposes two small on-demand tools —
+# skill_search (list matching summaries) and skill_load (inject one skill's
+# full instructions) — the tool-search pattern.
 - id: skill-filesystem
   name: '@deepseek-ai/dsh-skill-filesystem'
 
-- id: tool-skill
-  name: '@deepseek-ai/dsh-tool-skill'
+- id: skill-search
+  name: ./skill-search.mjs
 
 # ── goals ───────────────────────────────────────────────────────────────────
 

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -126,9 +126,14 @@
 # registry is an agent-owned service, so it lives in an entry-local realm; the
 # backend still consumes the host sandbox policy and subprocess implementation,
 # while the tool registers into this agent's scoped catalog.
+#
+# DISABLED ON WINDOWS: DSH's PTY backend is linux/darwin-only, so the
+# persistent shell cannot serve win32. The `custom-bash` row below registers
+# the same `bash` tool name there instead (platform-exclusive).
 - id: persistent-shell
   name: cordis:group
   group: true
+  disabled: !!js process.platform === 'win32'
   isolate:
     terminals: true
   config:
@@ -153,6 +158,19 @@
           * To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.
           * Please avoid commands that may produce a very large amount of output.
           * Please run long lived commands in the background, e.g. 'sleep 10 &' or start a server in the background.
+
+# Windows-only `bash` tool (see preset/custom-bash.mjs): registers the SAME
+# tool name as the persistent shell with a Minimal-compatible description, but
+# executes through the ordinary cross-platform subprocess seam (`bash -c`)
+# instead of a PTY. `bashPath` defaults to `bash` on PATH; point it at Git
+# Bash explicitly when the WSL shim would otherwise be picked up. No OS
+# sandbox confinement on Windows (landlock is linux-only); the tool
+# description says so.
+- id: custom-bash
+  name: ./custom-bash.mjs
+  disabled: !!js process.platform !== 'win32'
+  config:
+    bashPath: 'C:\Program Files\Git\bin\bash.exe'
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 

--- a/preset/compaction-epoch.mjs
+++ b/preset/compaction-epoch.mjs
@@ -1,0 +1,74 @@
+/**
+ * Epoch-aware promotion tracker shared by the bootstrap and baseline-gate
+ * plugins of the anchored presets.
+ *
+ * A compaction rewrites the model-visible surface: the pre-compaction
+ * conversation collapses into one synthetic summary message, and the
+ * workspace-instruction baseline is re-injected from scratch. The first
+ * post-compaction request is therefore a "second first request" — the same
+ * first-token conditions the anchored presets exist to control. Promotion is
+ * epoch-aware: only a durable promotion signal (`tool/call` and/or
+ * `assistant/message`, per the caller's `promoteEvents`) recorded AFTER the
+ * last `compaction/end` boundary counts as promoted. Before any compaction
+ * the boundary is -1, which preserves the original one-shot semantics.
+ *
+ * State is memoized per session id and maintained incrementally through
+ * `observe()`; a cold session scans its durable log once (so resume and
+ * reload reconstruct the same phase), then O(1).
+ */
+
+/** Build one epoch-aware promotion tracker. */
+export function createEpochPromotion(promoteEvents) {
+  const promote = new Set(promoteEvents)
+  /** sessionId -> { boundary, promoted } */
+  const state = new Map()
+
+  /** Scan a session's durable log from scratch (cold start / resume). */
+  const scan = (session) => {
+    let boundary = -1
+    let promoted = false
+    for (const event of session.events) {
+      const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
+      if (event.type === 'compaction/end') {
+        boundary = seq
+        promoted = false
+        continue
+      }
+      if (promote.has(event.type) && seq > boundary) promoted = true
+    }
+    const entry = { boundary, promoted }
+    state.set(session.id, entry)
+    return entry
+  }
+
+  return {
+    /**
+     * Current phase of the agent's session.
+     * @param agent - the assembly/pre-step agent, or undefined outside an agent.
+     * @returns { boundary, promoted } — `boundary` is the last compaction/end
+     *   seq (-1 before any compaction); `promoted` is true when a durable
+     *   promotion signal exists after that boundary.
+     */
+    status(agent) {
+      if (agent === undefined) return { boundary: -1, promoted: true }
+      const session = agent.session
+      if (session === undefined) return { boundary: -1, promoted: true }
+      // Subagents keep the full catalog from their very first request.
+      if ((session.header?.delegationDepth ?? 0) > 0) return { boundary: -1, promoted: true }
+      return state.get(session.id) ?? scan(session)
+    },
+    /** Incremental feed: call on every `session/event`. */
+    observe(session, event) {
+      const entry = state.get(session.id)
+      if (entry === undefined) return
+      const seq = event.seq ?? 0
+      if (event.type === 'compaction/end') {
+        state.set(session.id, { boundary: seq, promoted: false })
+        return
+      }
+      if (promote.has(event.type) && seq > entry.boundary && !entry.promoted) {
+        state.set(session.id, { ...entry, promoted: true })
+      }
+    },
+  }
+}

--- a/preset/custom-bash.mjs
+++ b/preset/custom-bash.mjs
@@ -1,0 +1,126 @@
+/**
+ * custom-bash — a Windows-capable `bash` tool that registers under the SAME
+ * name (`bash`) as the official persistent bash, with a Minimal-compatible
+ * description, but executes through `ctx.subprocess.spawn` instead of a PTY.
+ *
+ * WHY: DeepSeek's first-request trajectory anchor keys on the tool SCHEMA
+ * matching the RL training distribution (issue #11: persistent
+ * bash + str_replace_editor anchored 5/5 at maxTokens=256000, pwsh/read
+ * 8/8 standard-like). The official persistent bash uses a PTY, and DSH's PTY
+ * backend is linux/darwin-only — `subprocess-local` throws "terminal
+ * inspection is unsupported on platform win32". A custom tool that presents
+ * the same name and a Minimal-like description but spawns Git Bash through
+ * the ordinary (cross-platform) subprocess seam keeps the schema anchor
+ * without the PTY dependency.
+ *
+ * Executable resolution (config `bashPath`):
+ *  - explicit absolute path (e.g. `C:\Program Files\Git\bin\bash.exe`), or
+ *  - `bash` resolved through `ctx.subprocess.resolveExecutable` (PATH lookup).
+ *
+ * Semantics mirror the official bash tool: `bash -c <command>` in a fresh
+ * process, bounded output, non-zero exit reported not thrown. No sandbox
+ * confinement on Windows (the sandbox backend is linux-only); the tool
+ * description says so. The bootstrap catalog pairs this with
+ * `str_replace_editor` (Minimal's two tools).
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'custom-bash'
+
+/** The subprocess and tools services must exist before this tool can register. */
+export const inject = ['subprocess', 'tools']
+
+const DEFAULT_TIMEOUT_MS = 120000
+const DEFAULT_MAX_OUTPUT_BYTES = 64000
+
+/** Tool parameter schema for the model-facing command. */
+const commandSchema = {
+  type: 'object',
+  properties: {
+    command: {
+      type: 'string',
+      description: 'The bash command to execute (`bash -c` string domain).',
+    },
+    workdir: {
+      type: 'string',
+      description: 'Optional working directory; defaults to the session cwd.',
+    },
+  },
+  required: ['command'],
+  additionalProperties: false,
+}
+
+/** Register the model-facing `bash` tool. */
+export function apply(ctx, config) {
+  const bashPath = typeof config?.bashPath === 'string' && config.bashPath.length > 0 ? config.bashPath : 'bash'
+  const timeoutMs = Number.isSafeInteger(config?.timeoutMs) && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS
+  const maxOutputBytes = Number.isSafeInteger(config?.maxOutputBytes) && config.maxOutputBytes > 0 ? config.maxOutputBytes : DEFAULT_MAX_OUTPUT_BYTES
+
+  ctx.tools.register({
+    name: 'bash',
+    description: [
+      'Run commands in a bash shell (Git Bash on Windows)',
+      '* When invoking this tool, the contents of the "command" parameter does NOT need to be XML-escaped.',
+      "* You don't have access to the internet via this tool.",
+      '* You do have access to a mirror of common linux and python packages via apt and pip.',
+      '* State does NOT persist across command calls: each call runs in a fresh shell.',
+      "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
+      '* Please avoid commands that may produce a very large amount of output.',
+      '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+    ].join('\n'),
+    parameters: commandSchema,
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          text: { type: 'string' },
+        },
+        required: ['text'],
+      },
+      render: (_args, value) => [{ type: 'text', text: value.text }],
+    },
+    async execute(args, exec) {
+      const shell = await ctx.subprocess.resolveExecutable(bashPath, undefined, exec?.signal)
+      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+        ? args.workdir
+        : exec?.agent?.session?.header?.cwd
+      const signal = exec?.signal
+      const handle = ctx.subprocess.spawn({
+        argv: [shell, '-c', args.command],
+        ...workdir !== undefined ? { cwd: workdir } : {},
+        stdio: {
+          stdin: 'ignore',
+          stdout: { maxBytes: maxOutputBytes },
+          stderr: { maxBytes: maxOutputBytes },
+        },
+        ...signal !== undefined ? { signal } : {},
+        graceMs: 3000,
+      })
+      let outcome
+      try {
+        outcome = await handle.done
+      } catch (error) {
+        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+        // which the runtime turns into an isError result.
+        throw new Error(`bash spawn failed: ${String(error)}`)
+      }
+      let stdout = ''
+      let stderr = ''
+      try {
+        stdout = handle.collected.stdout.readFrom(0).text
+        stderr = handle.collected.stderr.readFrom(0).text
+      } catch {
+        // Collected readers may be unavailable on some backends; tolerate.
+      }
+      const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
+      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      if (outcome.exitCode !== 0) {
+        // Non-zero exit is a reported failure, not a throw: the model sees the
+        // command output plus the exit code.
+        throw new Error(tail)
+      }
+      return { text: tail }
+    },
+  })
+}

--- a/preset/dev-tool-search.mjs
+++ b/preset/dev-tool-search.mjs
@@ -1,0 +1,124 @@
+/**
+ * dev-tool-search — on-demand tool discovery and unlock, the tool-search
+ * pattern for the anchored preset.
+ *
+ * The promoted phase keeps only a minimal resident set (shell +
+ * str_replace_editor + the discovery tools) instead of dumping the whole
+ * Standard catalog at once. This plugin registers ONE small tool:
+ *
+ *  - `dev_tool_search` — search the FULL assembled catalog by keyword and
+ *    return matching tool names with short descriptions; optionally unlock
+ *    tools by exact name (array `toolNames`). Unlocked names are recorded as
+ *    durable `tool/call` arguments, and tool-bootstrap.mjs's assemble filter
+ *    exposes them from the next request on (resume-safe).
+ *
+ * The tool description is deliberately an INDEX of what the minimal resident
+ * set cannot do: the model should reach for dev_tool_search the moment a task
+ * needs internet, delegation, workflows, goals, images, background jobs, or
+ * multi-agent coordination — not try to work around them with bash.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'dev-tool-search'
+
+/** The tools registry must exist before this tool can register. */
+export const inject = ['tools']
+
+const MAX_RESULTS = 25
+
+/** Minimal JSON schema compiler for tool parameters (zero dependencies). */
+function toJsonSchema(spec) {
+  const properties = {}
+  const required = []
+  for (const [key, meta] of Object.entries(spec || {})) {
+    const prop = { type: meta.type }
+    if (meta.description) prop.description = meta.description
+    properties[key] = prop
+    if (meta.required) required.push(key)
+  }
+  return { type: 'object', properties, required, additionalProperties: false }
+}
+
+/**
+ * The capability index: resident minimal tools (bash / str_replace_editor /
+ * skill_search / skill_load) cannot cover these, so the model must search
+ * and unlock them on demand. Kept in the description so the model KNOWS what
+ * exists without a full catalog dump.
+ */
+const UNLOCKABLE_INDEX = [
+  'web_search — internet search and web retrieval',
+  'subagent / subagent_fork — delegate work to sub-agents',
+  'workflow — run multi-agent workflow scripts',
+  'ralph — fresh-agent iterative loop',
+  'create_goal / get_goal / update_goal — long-running goals',
+  'read_image — read image files',
+  'job_list / job_output / job_kill — background jobs',
+  'interrupt_agent / send_message / list_agents — multi-agent control',
+  'todo_write — task tracking',
+  'ask_user_question — ask the user',
+]
+
+/** Register the model-facing `dev_tool_search` tool. */
+export function apply(ctx) {
+  ctx.tools.register({
+    name: 'dev_tool_search',
+    description: [
+      'Discover and unlock tools that are NOT currently available.',
+      '',
+      'This session starts with a minimal resident set: bash, str_replace_editor, skill_search, skill_load. Everything else is unlocked on demand through this tool.',
+      '',
+      'If the current task needs any of the following, call dev_tool_search FIRST — do not try to work around them with bash:',
+      ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
+      '',
+      'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+    ].join('\n'),
+    parameters: toJsonSchema({
+      query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
+      toolNames: { type: 'array', required: false, description: 'exact tool names to unlock', items: { type: 'string' } },
+    }),
+    output: {
+      schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
+      render: (_a, v) => [{ type: 'text', text: v.text }],
+    },
+    async execute(args) {
+      const query = typeof args.query === 'string' ? args.query.trim() : ''
+      const unlock = Array.isArray(args.toolNames) ? args.toolNames.filter((name) => typeof name === 'string' && name.length > 0) : []
+
+      const lines = []
+      if (unlock.length > 0) {
+        lines.push(`Unlocked for the next request: ${unlock.join(', ')}`)
+      }
+      if (query.length === 0 && unlock.length === 0) {
+        lines.push('Provide `query` to search the catalog, or `toolNames` to unlock tools.')
+        return { text: lines.join('\n') }
+      }
+      if (query.length === 0) {
+        return { text: lines.join('\n') || 'Nothing to do.' }
+      }
+
+      try {
+        const schemas = ctx.tools.schemas()
+        const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
+        const matches = schemas
+          .filter((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            return wanted.every((token) => haystack.includes(token))
+          })
+          .slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(`No tools match "${query}".`)
+        } else {
+          lines.push(`Matching tools (${matches.length}):`)
+          for (const schema of matches) {
+            const desc = (schema.description || '').split('\n')[0].slice(0, 90)
+            lines.push(`- ${schema.name}: ${desc}`)
+          }
+          lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')
+        }
+      } catch (error) {
+        lines.push(`catalog search unavailable: ${String((error && error.message) || error)}`)
+      }
+      return { text: lines.join('\n') }
+    },
+  })
+}

--- a/preset/instruction-hint.mjs
+++ b/preset/instruction-hint.mjs
@@ -1,0 +1,178 @@
+/**
+ * instruction-hint — replace `dsh-agent-instructions`' full AGENTS.md/CLAUDE.md
+ * injection with a minimal "these files exist" hint.
+ *
+ * WHY: the full workspace-instruction digest is a large injected block. After
+ * the anchored bootstrap promotes, we want the model to KNOW the instruction
+ * files exist (so it reads them before acting) without dumping their content
+ * into every request. The model reads the files itself via the filesystem
+ * tools when it needs them.
+ *
+ * Behavior:
+ *  - After the session records its first durable promotion signal
+ *    (`promoteOn`, default `either`), ONE hint message is injected (once per
+ *    session — durable event scan, resume-safe), listing which instruction
+ *    files were found:
+ *      - user-global: `$DSH_HOME/AGENTS.md`
+ *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
+ *        walking up from the session cwd to the project root (a directory
+ *        containing `.git`, or the cwd itself).
+ *  - The hint instructs the model to READ the files before acting when
+ *    relevant, without embedding their content.
+ *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
+ *    service or an unreadable probe degrades to no hint (never throws).
+ *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
+ *
+ * ROW ORDER: this plugin registers its `agent/pre-step` handler with
+ * `prepend: true` and after `tool-bootstrap`, so it runs inside the
+ * bootstrap's outermost strip — but it emits AFTER promotion, when the strip
+ * is inactive. The hint source kind is `instruction-hint`, which is NOT in
+ * `suppressedContextSources`, so it is never stripped.
+ */
+
+import { createEpochPromotion } from './compaction-epoch.mjs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'instruction-hint'
+
+/** Durable session event types that count as a promotion signal per mode. */
+const PROMOTE_EVENTS = {
+  'tool-call': ['tool/call'],
+  'assistant-message': ['assistant/message'],
+  either: ['tool/call', 'assistant/message'],
+}
+
+/** Candidate file names, in probe order, for the project chain and user-global. */
+const PROJECT_CANDIDATES = ['AGENTS.md', 'CLAUDE.md', 'AGENTS.local.md', 'CLAUDE.local.md']
+const USER_GLOBAL_CANDIDATE = 'AGENTS.md'
+
+function parsePromoteOn(value) {
+  if (value === undefined || value === 'either') return PROMOTE_EVENTS.either
+  if (value === 'tool-call' || value === 'assistant-message') return PROMOTE_EVENTS[value]
+  throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
+}
+
+/** Find the project root: first ancestor containing any root marker (e.g. .git). */
+async function findProjectRoot(fs, cwd, signal) {
+  let current = cwd
+  for (;;) {
+    for (const marker of ['.git', '.hg', '.svn']) {
+      try {
+        const target = await fs.resolve(joinPath(current, marker), { cwd, signal })
+        const info = await fs.stat(target, signal)
+        if (info !== undefined) return current
+      } catch {
+        // Probe failure = marker absent; continue.
+      }
+    }
+    const parent = parentPath(current)
+    if (parent === current || parent.length === 0) return cwd
+    current = parent
+  }
+}
+
+/** List instruction files present in one directory (project candidates). */
+async function presentInDir(fs, dir, candidates, signal) {
+  const found = []
+  for (const candidate of candidates) {
+    try {
+      const target = await fs.resolve(joinPath(dir, candidate), { cwd: dir, signal })
+      const info = await fs.stat(target, signal)
+      if (info !== undefined && info.type === 'file') found.push(candidate)
+    } catch {
+      // Absent or unreadable — skip.
+    }
+  }
+  return found
+}
+
+/** Join one path segment onto a directory (platform-agnostic string join). */
+function joinPath(dir, segment) {
+  if (dir.endsWith('/') || dir.endsWith('\\')) return dir + segment
+  const sep = dir.includes('\\') ? '\\' : '/'
+  return dir + sep + segment
+}
+
+/** Parent of an absolute Windows or POSIX path. */
+function parentPath(path) {
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  if (idx <= 0) return path
+  const parent = path.slice(0, idx)
+  return parent.length === 0 ? path : parent
+}
+
+/** Register the post-promotion instruction-hint injector. */
+export function apply(ctx, config) {
+  const promoteEvents = parsePromoteOn(config.promoteOn)
+  const promotion = createEpochPromotion(promoteEvents)
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
+  /** Sessions that already received the hint. */
+  const hinted = new Set()
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  ctx.on('agent/pre-step', async ({ agent, signal }, next) => {
+    const decision = await next()
+    try {
+      if (promotion.status(agent).promoted !== true) return decision
+      const session = agent.session
+      if (session === undefined || hinted.has(session.id)) return decision
+      hinted.add(session.id)
+
+      const fs = ctx.get('fs')
+      if (fs === undefined) return decision
+      const cwd = session.header.cwd ?? process.cwd()
+
+      const projectFiles = []
+      const root = await findProjectRoot(fs, cwd, signal)
+      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+
+      const userGlobalFiles = []
+      try {
+        const dshHome = process.env.DSH_HOME ?? (process.env.USERPROFILE ? `${process.env.USERPROFILE}\\.dsh` : undefined)
+        if (dshHome !== undefined) {
+          userGlobalFiles.push(...await presentInDir(fs, dshHome, [USER_GLOBAL_CANDIDATE], signal))
+        }
+      } catch {
+        // Unreadable home probe — ignore.
+      }
+
+      const sections = []
+      if (projectFiles.length > 0) {
+        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+      }
+      if (userGlobalFiles.length > 0) {
+        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+      }
+      if (sections.length === 0) return decision
+
+      const text = [
+        ...sections,
+        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+      ].join(' ')
+
+      return {
+        ...decision,
+        messages: [...decision.messages, {
+          id: `instruction-hint-${session.id}`,
+          role: 'user',
+          content: [{ type: 'text', text }],
+          source: { kind: 'instruction-hint', form: 'hint' },
+        }],
+      }
+    } catch (error) {
+      // A hint bug must never hurt the session: skip the hint.
+      warnOnce(`${name}: hint injection failed, skipping: ${String((error && error.message) || error)}`)
+      return decision
+    }
+  }, { prepend: true })
+}

--- a/preset/skill-search.mjs
+++ b/preset/skill-search.mjs
@@ -1,0 +1,142 @@
+/**
+ * skill-search — on-demand skill discovery and loading, replacing
+ * `dsh-tool-skill`'s full-catalog injection.
+ *
+ * WHY: the available-skills reminder (`<available_skills>`, ~9KB with many
+ * skills) is injected into the first step by dsh-tool-skill and again after
+ * every promotion/compaction. That large injected block perturbs the
+ * trajectory (issue #6: 0/9 anchored with the catalog present vs ~81%
+ * without). We remove the catalog injection entirely and expose two small
+ * tools instead — the Claude tool-search pattern:
+ *
+ *  - `skill_search` — list skills whose name/description match a query
+ *    (summaries only, bounded; no bodies). The model discovers what exists
+ *    without a 9KB dump.
+ *  - `skill_load` — load ONE skill's full instructions by exact name and
+ *    inject them for the NEXT request via `agent.inject` (the non-waking
+ *    next-step inbox). The model (or the user) calls this only when the
+ *    skill is actually needed.
+ *
+ * Discovery reads `ctx.skills` scoped to the calling agent, exactly like
+ * dsh-tool-skill. If skills are unavailable the tools answer with a short
+ * message instead of throwing.
+ *
+ * NOTE: this plugin REPLACES the `dsh-tool-skill` row in the composition —
+ * the composition must NOT mount both, or the catalog injection returns.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'skill-search'
+
+/** The agent, tools, and skills services must exist before these tools can register. */
+export const inject = ['agents', 'tools', 'skills']
+
+const MAX_RESULTS = 20
+
+/** Minimal JSON schema compiler for tool parameters (zero dependencies). */
+function toJsonSchema(spec) {
+  const properties = {}
+  const required = []
+  for (const [key, meta] of Object.entries(spec || {})) {
+    const prop = { type: meta.type }
+    if (meta.description) prop.description = meta.description
+    properties[key] = prop
+    if (meta.required) required.push(key)
+  }
+  return { type: 'object', properties, required, additionalProperties: false }
+}
+
+/** Register the two on-demand skill tools. */
+export function apply(ctx) {
+  /** Normalize a query into lowercase tokens for simple substring matching. */
+  const tokens = (text) => (text || '').toLowerCase().split(/[^a-z0-9_-]+/).filter(Boolean)
+
+  ctx.tools.register({
+    name: 'skill_search',
+    description: 'Search the available skills by keyword and return matching skill names with short descriptions. This session keeps NO skill catalog in the prompt — if a task looks like it matches a skill (document conversion, image processing, game reviews, markdown, PDF, spreadsheets, …), call skill_search FIRST to find it, then skill_load to activate it. Do NOT assume skill names from memory.',
+    parameters: toJsonSchema({
+      query: { type: 'string', required: true, description: 'search keywords (e.g. "pdf", "obsidian", "game review")' },
+    }),
+    output: {
+      schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
+      render: (_a, v) => [{ type: 'text', text: v.text }],
+    },
+    async execute(args, exec) {
+      const wanted = tokens(args.query)
+      const scope = exec?.agent ?? ctx
+      try {
+        const all = await ctx.skills.list({
+          scope,
+          cwd: exec?.agent?.session?.header?.cwd,
+          signal: exec?.signal,
+        })
+        const matches = all.filter((skill) => {
+          if (wanted.length === 0) return true
+          const haystack = tokens(`${skill.name} ${skill.description ?? ''} ${skill.whenToUse ?? ''}`).join(' ')
+          return wanted.every((token) => haystack.includes(token))
+        })
+        const head = matches.slice(0, MAX_RESULTS)
+        const lines = head.map((skill) => {
+          const desc = (skill.description || '').split('\n')[0]
+          return `- ${skill.name}: ${desc}`
+        })
+        if (lines.length === 0) return { text: `No skills match "${args.query}". Use skill_search with other keywords.` }
+        const extra = matches.length > MAX_RESULTS ? `\n…(${matches.length - MAX_RESULTS} more)` : ''
+        return { text: `Matching skills (${matches.length}):\n${lines.join('\n')}${extra}\n\nLoad one with skill_load (exact name).` }
+      } catch (error) {
+        return { text: `skill_search unavailable: ${String((error && error.message) || error)}` }
+      }
+    },
+  })
+
+  ctx.tools.register({
+    name: 'skill_load',
+    description: 'Load the full instructions of ONE skill by its exact name (from skill_search results) and inject them for the next request. Call this before acting on a task that matches the skill.',
+    parameters: toJsonSchema({
+      name: { type: 'string', required: true, description: 'exact skill name (kebab-case, from skill_search)' },
+    }),
+    output: {
+      schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
+      render: (_a, v) => [{ type: 'text', text: v.text }],
+    },
+    async execute(args, exec) {
+      try {
+        const agent = exec?.agent
+        if (agent === undefined) return { text: 'skill_load requires an agent context.' }
+        const skill = await ctx.skills.get(args.name, {
+          scope: agent,
+          cwd: agent.session.header.cwd,
+          signal: exec?.signal,
+        })
+        if (skill === undefined) {
+          return { text: `No skill named "${args.name}". Run skill_search to list available skills.` }
+        }
+        const body = extractSkillBody(skill)
+        if (body.length === 0) {
+          return { text: `Skill "${args.name}" has no loadable body.` }
+        }
+        // Queue the skill content as a non-waking next-step context message,
+        // exactly like dsh-tool-skill's invocation injection.
+        agent.inject({
+          id: `skill-load-${args.name}-${Date.now()}`,
+          role: 'user',
+          content: [{ type: 'text', text: body }],
+          source: { kind: 'skill-invocation', name: args.name, form: 'instructions' },
+        })
+        return { text: `Skill "${args.name}" loaded; its instructions will be injected for the next request.` }
+      } catch (error) {
+        return { text: `skill_load failed: ${String((error && error.message) || error)}` }
+      }
+    },
+  })
+}
+
+/** Extract the model-facing body of a loaded skill definition. */
+function extractSkillBody(skill) {
+  const content = skill?.content ?? skill?.instructions ?? skill?.body
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content.map((part) => (typeof part === 'string' ? part : JSON.stringify(part))).join('\n')
+  }
+  return ''
+}

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -1,18 +1,18 @@
 /**
  * Anchored tool bootstrap — keep the FIRST model request on the Minimal
  * preset's REAL tool schema (persistent `bash` + `str_replace_editor`), free
- * of auto-injected workspace/skill context, then expose the full preset
- * catalog (and the normal context injections) once the session has produced
- * its first durable promotion signal.
+ * of auto-injected workspace/skill context, then narrow the catalog to a
+ * minimal RESIDENT set once the session has produced its first durable
+ * promotion signal.
  *
  * The phase is derived from durable session events, so resume and reload
  * preserve it. By default (`promoteOn: 'either'`) a session promotes after the
  * first `tool/call` OR the first `assistant/message`, whichever comes first:
  * request #1 always sees the bootstrap catalog and request #2 always sees the
- * full catalog. The original `'tool-call'` mode is kept for compatibility, but
- * it can trap a session in bootstrap forever when the first model reply makes
- * no tool call — the `'either'` default removes that trap while keeping the
- * first-request anchor intact.
+ * resident catalog. The original `'tool-call'` mode is kept for compatibility,
+ * but it can trap a session in bootstrap forever when the first model reply
+ * makes no tool call — the `'either'` default removes that trap while keeping
+ * the first-request anchor intact.
  *
  * First-request conditions established by the reproduction work (issues #6
  * and #11, 2026-08-15):
@@ -52,9 +52,31 @@
  *     set: it is not an automatic injection, and stripping it would lose the
  *     skill content once the gesture scrolls out of the per-step claim.
  *
+ * POST-PROMOTION RESIDENT SET (local addition, user-measured): the promoted
+ * phase does NOT dump the whole Standard catalog at once — that dump pulls
+ * the trajectory back to standard-like behavior (the root cause of the
+ * post-promotion regression measured on the zero variant). Instead the
+ * catalog narrows to the bootstrap tool pair PLUS the three discovery tools
+ * (`dev_tool_search`, `skill_search`, `skill_load`) plus whatever the model
+ * explicitly unlocked via `dev_tool_search`. Heavier Standard tools
+ * (web_search, subagent, workflow, …) are one `dev_tool_search` call away;
+ * unlocked names are derived from durable `tool/call` events, so resume and
+ * reload keep them. read/write/edit/glob/grep/todo/ask are deliberately NOT
+ * resident: bash + str_replace_editor cover file work.
+ *
+ * COMPACTION (local addition): a compaction rewrites the whole surface, so the
+ * first post-compaction request is a "second first request". Promotion is
+ * epoch-aware (see compaction-epoch.mjs): after `compaction/end` the session
+ * falls back to the controlled phase — the bootstrap pair plus
+ * `compactionTools` (a core work set, default none) — until a NEW durable
+ * promotion signal exists past that boundary. The model is mid-task and needs
+ * to keep working, but still faces a small catalog instead of the full
+ * Standard set.
+ *
  * Robustness:
  *  - Promotion decisions are memoized per session id for this process; the
  *    durable event scan runs once per session per process, then O(1).
+ *  - Subagents (delegationDepth > 0) are always promoted (resident catalog).
  *  - A missing bootstrap tool degrades to the full catalog with a one-time
  *    warning instead of throwing, so a composition drift can never brick
  *    every request of a session.
@@ -64,6 +86,8 @@
  *    `suppressedContextSources`, non-positive `bootstrapMaxTokens`) fails at
  *    apply time, i.e. at preset mount, where it is visible and fixable.
  */
+
+import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
 export const name = 'anchored-tool-bootstrap'
@@ -104,11 +128,19 @@ const DEFAULT_SUPPRESSED_SOURCES = ['skill-catalog', 'agent-instructions']
  */
 const DEFAULT_BOOTSTRAP_TOOLS = ['bash', 'str_replace_editor']
 
+/** Discovery tools always resident after promotion (the tool-search pattern). */
+const RESIDENT_DISCOVERY_TOOLS = ['dev_tool_search', 'skill_search', 'skill_load']
+
 function stringList(value, field) {
   if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
     throw new TypeError(`${name}: ${field} must be a non-empty array of non-empty strings`)
   }
   return [...new Set(value)]
+}
+
+function stringListOrEmpty(value, field) {
+  if (value === undefined) return []
+  return stringList(value, field)
 }
 
 function parsePromoteOn(value) {
@@ -150,9 +182,14 @@ export function apply(ctx, config) {
   const promoteEvents = parsePromoteOn(config.promoteOn)
   const bootstrapMaxTokens = optionalPositiveInt(config.bootstrapMaxTokens, 'bootstrapMaxTokens')
   const suppressedSources = sourceList(config.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+  // Core work set exposed after a compaction, before re-promotion. Empty
+  // means "no compaction recovery catalog": the session stays on the
+  // bootstrap pair until a new promotion signal.
+  const compactionTools = stringListOrEmpty(config.compactionTools, 'compactionTools')
 
-  /** Sessions already promoted in this process. Promotion is append-only, so a Set is sound. */
-  const promoted = new Set()
+  const promotion = createEpochPromotion(promoteEvents)
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
   let warned = false
   const warnOnce = (message) => {
     if (warned) return
@@ -165,33 +202,44 @@ export function apply(ctx, config) {
   }
 
   /**
-   * Whether the session has reached the promoted phase.
-   * @param agent - the assembly context's agent, or undefined outside an agent.
+   * Tool names the model explicitly unlocked via `dev_tool_search` for one
+   * session. Derived from durable `tool/call` events so resume/reload keeps
+   * them. The event's `arguments` is the raw JSON string the model produced;
+   * we parse it defensively and read the `toolNames` array.
    */
-  const isPromoted = (agent) => {
-    if (agent === undefined) return true
-    const session = agent.session
-    if (session === undefined) return true
-    if (promoted.has(session.id)) return true
-    const hit = session.events.some((event) => promoteEvents.includes(event.type))
-    if (hit) promoted.add(session.id)
-    return hit
+  const unlockedFor = (session) => {
+    const unlocked = new Set()
+    if (session === undefined || !Array.isArray(session.events)) return unlocked
+    for (const event of session.events) {
+      if (event.type !== 'tool/call') continue
+      if (event.data?.name !== 'dev_tool_search') continue
+      let args
+      try {
+        args = JSON.parse(event.data.arguments)
+      } catch {
+        continue
+      }
+      if (args === null || typeof args !== 'object' || Array.isArray(args)) continue
+      const names = args.toolNames
+      if (Array.isArray(names)) for (const name of names) if (typeof name === 'string' && name.length > 0) unlocked.add(name)
+    }
+    return unlocked
   }
 
-  /** Narrow the assembled catalog to the bootstrap tool set. */
-  const applyBootstrap = (assembled) => {
+  /** Narrow the assembled catalog to a keep-set; validate required names. */
+  const keepTools = (assembled, keep, missingAllowsFullCatalog) => {
     const available = new Set(assembled.tools.map((tool) => tool.name))
-    const missing = bootstrapTools.filter((toolName) => !available.has(toolName))
+    const missing = [...keep].filter((toolName) => !available.has(toolName))
     if (missing.length > 0) {
       warnOnce(
-        `${name}: expected every bootstrap tool; missing=${JSON.stringify(missing)} — `
-        + 'bootstrap disabled, full catalog exposed',
+        `${name}: expected every phase tool; missing=${JSON.stringify(missing)} — `
+        + (missingAllowsFullCatalog ? 'bootstrap disabled, full catalog exposed' : 'continuing with what is available'),
       )
-      return assembled
+      if (missingAllowsFullCatalog) return assembled
     }
     return {
       ...assembled,
-      tools: assembled.tools.filter((tool) => bootstrapTools.includes(tool.name)),
+      tools: assembled.tools.filter((tool) => keep.has(tool.name)),
     }
   }
 
@@ -199,8 +247,21 @@ export function apply(ctx, config) {
     // Downstream errors propagate untouched; only this filter's own logic is guarded.
     const assembled = await next()
     try {
-      if (isPromoted(context.agent)) return assembled
-      return applyBootstrap(assembled)
+      const status = promotion.status(context.agent)
+      if (status.promoted) {
+        // PROMOTED: keep the minimal resident set — the bootstrap pair + the
+        // discovery tools + whatever the model explicitly unlocked via
+        // dev_tool_search — instead of dumping the whole Standard catalog at
+        // once (the post-promotion regression fix; see the header note).
+        const keep = new Set([...bootstrapTools, ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session)])
+        return keepTools(assembled, keep, false)
+      }
+      // Controlled phase: the bootstrap pair; after a compaction, plus the
+      // compaction work set so mid-task work can continue.
+      const { boundary } = status
+      const keep = new Set(bootstrapTools)
+      if (boundary >= 0) for (const toolName of compactionTools) keep.add(toolName)
+      return keepTools(assembled, keep, true)
     } catch (error) {
       // A filter bug must never brick a session: degrade to the full catalog.
       warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
@@ -221,7 +282,7 @@ export function apply(ctx, config) {
     ctx.on('agent/request', async (payload, next) => {
       const resolved = await next()
       const agent = payload.agent
-      if (isPromoted(agent)) {
+      if (promotion.status(agent).promoted) {
         // The next request's seed proposal carries the previous header's
         // maxTokens forward, so the injected cap must be stripped explicitly —
         // otherwise it would persist for the whole session.
@@ -248,7 +309,7 @@ export function apply(ctx, config) {
     const decision = await next()
     if (decision.kind === 'reject') return decision
     try {
-      if (isPromoted(agent) || suppressedSources.size === 0) return decision
+      if (promotion.status(agent).promoted || suppressedSources.size === 0) return decision
       if (!Array.isArray(decision.messages)) return decision
       const kept = decision.messages.filter((message) => {
         const kind = message?.source?.kind

--- a/test/compaction-epoch.test.mjs
+++ b/test/compaction-epoch.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createEpochPromotion } from '../preset/compaction-epoch.mjs'
+
+const session = (events, header = {}, id = 's') => ({ id, events, header })
+
+test('no events: un-promoted, boundary -1', () => {
+  const promotion = createEpochPromotion(['tool/call', 'assistant/message'])
+  const status = promotion.status({ session: session([]) })
+  assert.equal(status.promoted, false)
+  assert.equal(status.boundary, -1)
+})
+
+test('a promotion signal before any compaction promotes', () => {
+  const promotion = createEpochPromotion(['tool/call', 'assistant/message'])
+  const s = session([{ type: 'assistant/message', seq: 0, data: {} }])
+  assert.equal(promotion.status({ session: s }).promoted, true)
+})
+
+test('incremental observe promotes O(1) after the cold scan', () => {
+  const promotion = createEpochPromotion(['assistant/message'])
+  const s = session([])
+  assert.equal(promotion.status({ session: s }).promoted, false)
+  promotion.observe(s, { type: 'assistant/message', seq: 1, data: {} })
+  assert.equal(promotion.status({ session: s }).promoted, true)
+  // observe is a no-op on a session this process never scanned
+  const foreign = session([], {}, 'foreign')
+  promotion.observe(foreign, { type: 'assistant/message', seq: 1, data: {} })
+  assert.equal(promotion.status({ session: foreign }).promoted, false)
+})
+
+test('a compaction resets promotion regardless of earlier signals', () => {
+  const promotion = createEpochPromotion(['tool/call', 'assistant/message'])
+  const s = session([
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ])
+  const status = promotion.status({ session: s })
+  assert.equal(status.promoted, false)
+  assert.equal(status.boundary, 2)
+})
+
+test('only signals AFTER the compaction boundary count (old signals stay dead)', () => {
+  const promotion = createEpochPromotion(['tool/call', 'assistant/message'])
+  const s = session([
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'tool/call', seq: 2, data: {} },
+    { type: 'compaction/end', seq: 3 },
+  ])
+  assert.equal(promotion.status({ session: s }).promoted, false)
+  // A NEW signal past the boundary re-promotes.
+  promotion.observe(s, { type: 'assistant/message', seq: 4, data: {} })
+  assert.equal(promotion.status({ session: s }).promoted, true)
+})
+
+test('observe across the boundary flips the phase immediately', () => {
+  const promotion = createEpochPromotion(['assistant/message'])
+  const s = session([{ type: 'assistant/message', seq: 1, data: {} }])
+  assert.equal(promotion.status({ session: s }).promoted, true)
+  promotion.observe(s, { type: 'compaction/end', seq: 2 })
+  assert.equal(promotion.status({ session: s }).promoted, false)
+  promotion.observe(s, { type: 'assistant/message', seq: 3, data: {} })
+  assert.equal(promotion.status({ session: s }).promoted, true)
+})
+
+test('multiple compactions: the LAST boundary wins', () => {
+  const promotion = createEpochPromotion(['assistant/message'])
+  const s = session([
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+    { type: 'assistant/message', seq: 3, data: {} },
+    { type: 'compaction/end', seq: 4 },
+  ])
+  const status = promotion.status({ session: s })
+  assert.equal(status.promoted, false)
+  assert.equal(status.boundary, 4)
+})
+
+test('subagents (delegationDepth > 0) are always promoted', () => {
+  const promotion = createEpochPromotion(['tool/call'])
+  const s = session([], { delegationDepth: 1 })
+  assert.equal(promotion.status({ session: s }).promoted, true)
+})
+
+test('undefined agent or session is always promoted (defensive)', () => {
+  const promotion = createEpochPromotion(['tool/call'])
+  assert.equal(promotion.status(undefined).promoted, true)
+  assert.equal(promotion.status({ session: undefined }).promoted, true)
+})
+
+test('a session header without delegationDepth is treated as top-level', () => {
+  const promotion = createEpochPromotion(['tool/call'])
+  const s = session([], {})
+  assert.equal(promotion.status({ session: s }).promoted, false)
+})

--- a/test/custom-bash.test.mjs
+++ b/test/custom-bash.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name, inject } from '../preset/custom-bash.mjs'
+
+function register(config) {
+  const registered = []
+  const spawnCalls = []
+  const ctx = {
+    subprocess: {
+      async resolveExecutable(path) {
+        return path
+      },
+      spawn(options) {
+        spawnCalls.push(options)
+        return {
+          done: Promise.resolve({ exitCode: 0 }),
+          collected: {
+            stdout: { readFrom() { return { text: 'hello from bash' } } },
+            stderr: { readFrom() { return { text: '' } } },
+          },
+        }
+      },
+    },
+    tools: {
+      register(tool) {
+        registered.push(tool)
+      },
+    },
+  }
+  apply(ctx, config)
+  return { tool: registered[0], spawnCalls, ctx }
+}
+
+const exec = (overrides = {}) => ({
+  agent: { session: { id: 's', header: { cwd: 'C:/work' } } },
+  signal: undefined,
+  ...overrides,
+})
+
+test('exports a diagnostic plugin name and injects subprocess + tools', () => {
+  assert.equal(name, 'custom-bash')
+  assert.deepEqual(inject.sort(), ['subprocess', 'tools'].sort())
+})
+
+test('registers the bash tool with a Minimal-compatible description', () => {
+  const { tool } = register()
+  assert.equal(tool.name, 'bash')
+  assert.match(tool.description, /Run commands in a bash shell/)
+  assert.ok(tool.parameters.required.includes('command'))
+  assert.ok(tool.output.schema)
+})
+
+test('execute spawns `bash -c <command>` and returns the combined output', async () => {
+  const { tool, spawnCalls } = register({ bashPath: 'C:/Program Files/Git/bin/bash.exe' })
+  const result = await tool.execute({ command: 'echo hi' }, exec())
+  assert.equal(result.text, 'hello from bash')
+  assert.equal(spawnCalls.length, 1)
+  assert.deepEqual(spawnCalls[0].argv, ['C:/Program Files/Git/bin/bash.exe', '-c', 'echo hi'])
+})
+
+test('execute passes the session cwd by default and honors an explicit workdir', async () => {
+  const { tool, spawnCalls } = register()
+  await tool.execute({ command: 'pwd' }, exec())
+  assert.equal(spawnCalls[0].cwd, 'C:/work')
+  await tool.execute({ command: 'pwd', workdir: 'D:/other' }, exec())
+  assert.equal(spawnCalls[1].cwd, 'D:/other')
+})
+
+test('a non-zero exit throws with the captured output', async () => {
+  const registered = []
+  const ctx = {
+    subprocess: {
+      async resolveExecutable(path) { return path },
+      spawn() {
+        return {
+          done: Promise.resolve({ exitCode: 2 }),
+          collected: {
+            stdout: { readFrom() { return { text: 'boom' } } },
+            stderr: { readFrom() { return { text: '' } } },
+          },
+        }
+      },
+    },
+    tools: { register(t) { registered.push(t) } },
+  }
+  apply(ctx)
+  await assert.rejects(() => registered[0].execute({ command: 'false' }, exec()), /boom/)
+})
+
+test('a spawn-level failure throws a descriptive error', async () => {
+  const registered = []
+  const ctx = {
+    subprocess: {
+      async resolveExecutable(path) { return path },
+      spawn() {
+        return { done: Promise.reject(new Error('EPERM: operation not permitted')) }
+      },
+    },
+    tools: { register(t) { registered.push(t) } },
+  }
+  apply(ctx)
+  await assert.rejects(() => registered[0].execute({ command: 'x' }, exec()), /bash spawn failed/)
+})
+
+test('missing output readers degrade to the exit code text', async () => {
+  const registered = []
+  const ctx = {
+    subprocess: {
+      async resolveExecutable(path) { return path },
+      spawn() {
+        return {
+          done: Promise.resolve({ exitCode: 0 }),
+          collected: {
+            stdout: { readFrom() { throw new Error('unavailable') } },
+            stderr: { readFrom() { throw new Error('unavailable') } },
+          },
+        }
+      },
+    },
+    tools: { register(t) { registered.push(t) } },
+  }
+  apply(ctx)
+  const result = await registered[0].execute({ command: 'x' }, exec())
+  assert.match(result.text, /exit code: 0/)
+})
+
+test('the default bashPath falls back to `bash` on PATH', async () => {
+  const resolved = []
+  const registered = []
+  const ctx = {
+    subprocess: {
+      async resolveExecutable(path) { resolved.push(path); return path },
+      spawn() { return { done: Promise.resolve({ exitCode: 0 }), collected: { stdout: { readFrom() { return { text: 'ok' } } }, stderr: { readFrom() { return { text: '' } } } } } },
+    },
+    tools: { register(t) { registered.push(t) } },
+  }
+  apply(ctx)
+  await registered[0].execute({ command: 'x' }, exec())
+  assert.deepEqual(resolved, ['bash'])
+})

--- a/test/dev-tool-search.test.mjs
+++ b/test/dev-tool-search.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../preset/dev-tool-search.mjs'
+
+function register(schemas = []) {
+  const registered = []
+  const ctx = {
+    tools: {
+      schemas() {
+        return schemas
+      },
+      register(tool) {
+        registered.push(tool)
+      },
+    },
+  }
+  apply(ctx)
+  return { registered, ctx }
+}
+
+const exec = (args) => ({ agent: { session: { id: 's', header: {} } }, signal: undefined, ...args })
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'dev-tool-search')
+})
+
+test('registers the dev_tool_search tool with an unlock capability index', () => {
+  const { registered } = register()
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  assert.ok(tool)
+  assert.match(tool.description, /web_search/)
+  assert.match(tool.description, /subagent/)
+  assert.ok(tool.parameters.properties.query)
+  assert.ok(tool.parameters.properties.toolNames)
+  assert.ok(tool.output.schema)
+})
+
+test('search returns matching tool names with descriptions', async () => {
+  const { registered } = register([
+    { name: 'web_search', description: 'internet search' },
+    { name: 'bash', description: 'run commands' },
+    { name: 'subagent', description: 'delegate work' },
+  ])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({ query: 'search internet' }, exec())
+  assert.match(result.text, /web_search/)
+  assert.doesNotMatch(result.text, /bash/)
+  assert.doesNotMatch(result.text, /subagent/)
+})
+
+test('no match reports so and still hints at unlocking', async () => {
+  const { registered } = register([{ name: 'bash', description: 'run commands' }])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({ query: 'zzz-nothing' }, exec())
+  assert.match(result.text, /No tools match/)
+})
+
+test('unlock names are echoed back (the bootstrap records them from tool/call events)', async () => {
+  const { registered } = register([{ name: 'web_search', description: 'internet search' }])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({ toolNames: ['web_search'] }, exec())
+  assert.match(result.text, /Unlocked for the next request: web_search/)
+})
+
+test('empty query and empty toolNames asks for input', async () => {
+  const { registered } = register([])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({}, exec())
+  assert.match(result.text, /Provide `query`/)
+})
+
+test('a throwing catalog search degrades to a message, never throws', async () => {
+  const spy = { tools: { schemas() { throw new Error('registry unavailable') }, register(t) { this.registered = t } } }
+  apply(spy)
+  const result = await spy.tools.registered.execute({ query: 'web' }, exec())
+  assert.match(result.text, /catalog search unavailable/)
+})

--- a/test/instruction-hint.test.mjs
+++ b/test/instruction-hint.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../preset/instruction-hint.mjs'
+
+const PROJ_FILES = ['AGENTS.md', 'CLAUDE.md']
+const GLOBAL_FILES = []
+
+function register(header = {}) {
+  const listeners = {}
+  const hookOptions = {}
+  const fs = {
+    async resolve(target) {
+      return target
+    },
+    async stat(target) {
+      const base = target.replace(/\\/g, '/').split('/').pop()
+      if (PROJ_FILES.includes(base)) return { type: 'file' }
+      if (GLOBAL_FILES.includes(base)) return { type: 'file' }
+      if (base === '.git' || base === '.hg' || base === '.svn') return { type: 'directory' }
+      throw new Error('ENOENT')
+    },
+  }
+  const ctx = {
+    on(event, callback, options) {
+      listeners[event] = callback
+      hookOptions[event] = options
+    },
+    get(service) {
+      if (service === 'fs') return fs
+      return undefined
+    },
+    logger: { warn() {} },
+  }
+  apply(ctx, { promoteOn: 'either' })
+  return { listeners, hookOptions }
+}
+
+const session = (events, header = {}) => ({ id: 's', events, header: { cwd: 'C:/work', ...header } })
+
+const decision = () => ({ kind: 'enter', messages: [{ id: 'u', role: 'user', content: [{ type: 'text', text: 'hi' }], source: { kind: 'user' } }] })
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'instruction-hint')
+})
+
+test('pre-promotion requests get NO hint', async () => {
+  const { listeners } = register()
+  const d = decision()
+  const result = await listeners['agent/pre-step'](
+    { agent: { session: session([]) } },
+    async () => d,
+  )
+  assert.equal(result, d)
+})
+
+test('after promotion ONE hint is injected once per session', async () => {
+  const { listeners } = register()
+  const agent = { session: session([{ type: 'assistant/message', seq: 1, data: {} }]) }
+  const first = await listeners['agent/pre-step']({ agent }, async () => decision())
+  assert.equal(first.messages.length, 2)
+  const hint = first.messages[1]
+  assert.equal(hint.source.kind, 'instruction-hint')
+  assert.match(hint.content[0].text, /AGENTS\.md, CLAUDE\.md/)
+  // Second call for the same session: no duplicate hint.
+  const second = await listeners['agent/pre-step']({ agent }, async () => decision())
+  assert.equal(second.messages.length, 1)
+})
+
+test('no instruction files found → no hint message', async () => {
+  const listeners = {}
+  const fs = {
+    async resolve(target) { return target },
+    async stat() { throw new Error('ENOENT') },
+  }
+  const ctx = {
+    on(event, callback) { listeners[event] = callback },
+    get(service) { return service === 'fs' ? fs : undefined },
+    logger: { warn() {} },
+  }
+  apply(ctx, { promoteOn: 'either' })
+  const agent = { session: session([{ type: 'assistant/message', seq: 1, data: {} }]) }
+  const result = await listeners['agent/pre-step']({ agent }, async () => decision())
+  assert.equal(result.messages.length, 1)
+})
+
+test('missing fs service degrades to no hint (never throws)', async () => {
+  const listeners = {}
+  const ctx = {
+    on(event, callback) { listeners[event] = callback },
+    get() { return undefined },
+    logger: { warn() {} },
+  }
+  apply(ctx, { promoteOn: 'either' })
+  const agent = { session: session([{ type: 'assistant/message', seq: 1, data: {} }]) }
+  const result = await listeners['agent/pre-step']({ agent }, async () => decision())
+  assert.equal(result.messages.length, 1)
+})
+
+test('the hint registers with prepend', () => {
+  const { hookOptions } = register()
+  assert.deepEqual(hookOptions['agent/pre-step'], { prepend: true })
+})

--- a/test/skill-search.test.mjs
+++ b/test/skill-search.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../preset/skill-search.mjs'
+
+function register(skills = []) {
+  const registered = []
+  const injected = []
+  const ctx = {
+    skills: {
+      async list() {
+        return skills
+      },
+      async get(skillName) {
+        return skills.find((skill) => skill.name === skillName)
+      },
+    },
+    tools: {
+      register(tool) {
+        registered.push(tool)
+      },
+    },
+    agents: {},
+  }
+  apply(ctx)
+  return { registered, injected, ctx }
+}
+
+const exec = () => ({
+  agent: { session: { id: 's', header: { cwd: '/work' } } },
+  signal: undefined,
+})
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'skill-search')
+})
+
+test('registers skill_search and skill_load', () => {
+  const { registered } = register()
+  const names = registered.map((tool) => tool.name)
+  assert.deepEqual(names.sort(), ['skill_load', 'skill_search'])
+})
+
+test('skill_search lists matching skills by keyword, summaries only', async () => {
+  const { registered } = register([
+    { name: 'pdf-tools', description: 'PDF manipulation toolkit' },
+    { name: 'obsidian-vault', description: 'knowledge wiki' },
+    { name: 'game-review', description: 'GDD review' },
+  ])
+  const search = registered.find((tool) => tool.name === 'skill_search')
+  const result = await search.execute({ query: 'pdf' }, exec())
+  assert.match(result.text, /pdf-tools/)
+  assert.doesNotMatch(result.text, /obsidian-vault/)
+  assert.doesNotMatch(result.text, /game-review/)
+})
+
+test('skill_search with no query lists everything (bounded)', async () => {
+  const { registered } = register([{ name: 'a', description: 'x' }, { name: 'b', description: 'y' }])
+  const search = registered.find((tool) => tool.name === 'skill_search')
+  const result = await search.execute({ query: '' }, exec())
+  assert.match(result.text, /a:/)
+  assert.match(result.text, /b:/)
+})
+
+test('skill_search with no matches says so', async () => {
+  const { registered } = register([{ name: 'pdf-tools', description: 'PDF' }])
+  const search = registered.find((tool) => tool.name === 'skill_search')
+  const result = await search.execute({ query: 'quantum' }, exec())
+  assert.match(result.text, /No skills match/)
+})
+
+test('skill_load injects the skill body for the next request via agent.inject', async () => {
+  const { registered } = register([{ name: 'pdf-tools', description: 'PDF', content: '# PDF Tools\nfull instructions' }])
+  let injected = null
+  const agent = { session: { id: 's', header: { cwd: '/work' } }, inject(message) { injected = message } }
+  const load = registered.find((tool) => tool.name === 'skill_load')
+  const result = await load.execute({ name: 'pdf-tools' }, { agent })
+  assert.match(result.text, /loaded/)
+  assert.ok(injected)
+  assert.equal(injected.source.kind, 'skill-invocation')
+  assert.match(injected.content[0].text, /full instructions/)
+})
+
+test('skill_load with an unknown name reports without injecting', async () => {
+  const { registered } = register([])
+  const load = registered.find((tool) => tool.name === 'skill_load')
+  const result = await load.execute({ name: 'nope' }, exec())
+  assert.match(result.text, /No skill named/)
+})
+
+test('a throwing skills service degrades to a message, never throws', async () => {
+  const spy = {
+    skills: {
+      async list() {
+        throw new Error('skills registry unavailable')
+      },
+      async get() {
+        throw new Error('skills registry unavailable')
+      },
+    },
+    tools: { register(t) { (this.registered ??= []).push(t) } },
+    agents: {},
+  }
+  apply(spy)
+  const search = spy.tools.registered.find((tool) => tool.name === 'skill_search')
+  const result = await search.execute({ query: 'pdf' }, exec())
+  assert.match(result.text, /skill_search unavailable/)
+})

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -63,18 +63,21 @@ test('first request exposes exactly the Minimal tool pair', async () => {
   assert.deepEqual(result.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
-test('a durable tool call promotes the complete catalog', async () => {
+test('a durable tool call promotes the resident catalog', async () => {
   const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'edit' }, { name: 'grep' }]
   const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call', data: { name: 'bash' } }], tools)
-  assert.deepEqual(result.tools, tools)
+  // Promoted: the bootstrap pair only — read/edit/grep are NOT resident
+  // (bash + str_replace_editor cover file work; heavier tools are one
+  // dev_tool_search away).
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
-test('a first assistant message promotes the complete catalog (no tool call needed)', async () => {
+test('a first assistant message promotes the resident catalog (no tool call needed)', async () => {
   const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'write' }]
   const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools)
-  assert.deepEqual(result.tools, tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
 test('sessions derive promotion independently from their own events', async () => {
@@ -82,7 +85,7 @@ test('sessions derive promotion independently from their own events', async () =
   const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'write' }]
   const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'a')
   const fresh = await assemble(listeners['system-prompt/assemble'], [], tools, 'b')
-  assert.deepEqual(promoted.tools, tools)
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
   assert.deepEqual(fresh.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
@@ -90,10 +93,10 @@ test('promotion is memoized per session id within one process', async () => {
   const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'write' }]
   const first = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'memo')
-  assert.deepEqual(first.tools, tools)
+  assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
   // Same session id, events now empty: the cached decision still promotes.
   const second = await assemble(listeners['system-prompt/assemble'], [], tools, 'memo')
-  assert.deepEqual(second.tools, tools)
+  assert.deepEqual(second.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
 test('promoteOn tool-call requires a tool call, not just a reply', async () => {
@@ -102,14 +105,14 @@ test('promoteOn tool-call requires a tool call, not just a reply', async () => {
   const replyOnly = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, 'a')
   assert.deepEqual(replyOnly.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
   const withCall = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'b')
-  assert.deepEqual(withCall.tools, tools)
+  assert.deepEqual(withCall.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
 test('promoteOn assistant-message promotes after any first reply', async () => {
   const { listeners } = register({ ...config, promoteOn: 'assistant-message' })
   const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'write' }]
   const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, 'a')
-  assert.deepEqual(result.tools, tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
 test('a missing bootstrap tool degrades gracefully to the full catalog', async () => {
@@ -197,9 +200,10 @@ test('promoted pre-step keeps every injected context message', async () => {
 
 test('a text-only first reply promotes the context injections too', async () => {
   const { listeners } = register()
-  const stripped = await prestep(listeners['agent/pre-step'], [], [userMessage, instructionMessage, catalogMessage])
+  const stripped = await prestep(listeners['agent/pre-step'], [], [userMessage, instructionMessage, catalogMessage], 'a')
   assert.deepEqual(stripped.messages.map((message) => message.id), ['u'])
-  const kept = await prestep(listeners['agent/pre-step'], [{ type: 'assistant/message' }], [userMessage, instructionMessage])
+  // Distinct session id: the first (un-promoted) scan must not shadow this one.
+  const kept = await prestep(listeners['agent/pre-step'], [{ type: 'assistant/message' }], [userMessage, instructionMessage], 'b')
   assert.deepEqual(kept.messages.map((message) => message.id), ['u', 'i'])
 })
 
@@ -235,4 +239,112 @@ test('the pre-step strip and the budget cap both register with prepend', () => {
   const { hookOptions } = register({ ...config, bootstrapMaxTokens: 1024 })
   assert.deepEqual(hookOptions['agent/pre-step'], { prepend: true })
   assert.deepEqual(hookOptions['agent/request'], { prepend: true })
+})
+
+// ── local additions: resident set, dev_tool_search unlock, compaction ──────
+
+test('the promoted resident set includes the discovery tools when available', async () => {
+  const { listeners } = register()
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }, { name: 'edit' },
+    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' }, { name: 'web_search' },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), [
+    'bash', 'dev_tool_search', 'skill_load', 'skill_search', 'str_replace_editor',
+  ])
+})
+
+test('dev_tool_search unlocks tools durably (resume-safe from tool/call events)', async () => {
+  const { listeners } = register()
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' }, { name: 'dev_tool_search' },
+    { name: 'skill_search' }, { name: 'skill_load' }, { name: 'web_search' }, { name: 'subagent' },
+  ]
+  const events = [
+    { type: 'assistant/message', data: {} },
+    { type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["web_search","subagent"]}' } },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  const names = result.tools.map((tool) => tool.name)
+  assert.ok(names.includes('web_search'))
+  assert.ok(names.includes('subagent'))
+})
+
+test('malformed dev_tool_search arguments are ignored, not fatal', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'dev_tool_search' }]
+  const events = [
+    { type: 'assistant/message', data: {} },
+    { type: 'tool/call', data: { name: 'dev_tool_search', arguments: 'not json' } },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ['bash', 'dev_tool_search', 'str_replace_editor'])
+})
+
+test('post-compaction falls back to the bootstrap pair plus compactionTools', async () => {
+  const { listeners } = register({ ...config, compactionTools: ['read', 'todo_write'] })
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }, { name: 'todo_write' }, { name: 'web_search' },
+  ]
+  const events = [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ['bash', 'read', 'str_replace_editor', 'todo_write'])
+})
+
+test('post-compaction without compactionTools stays on the bootstrap pair', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
+  const events = [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ['bash', 'str_replace_editor'])
+})
+
+test('a compaction resets promotion; a new signal after the boundary re-promotes', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
+  const events = [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ]
+  const postCompaction = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(postCompaction.tools.map((tool) => tool.name).sort(), ['bash', 'str_replace_editor'])
+  // The live harness feeds new events through session/event; emulate that.
+  listeners['session/event']({ id: 's', events }, { type: 'tool/call', seq: 3, data: { name: 'bash' } })
+  const rePromoted = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(rePromoted.tools.map((tool) => tool.name).sort(), ['bash', 'str_replace_editor'])
+})
+
+test('pre-compaction promotion signals do not re-promote after a compaction', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
+  // The assistant/message (seq 1) sits BEFORE the compaction boundary (seq 2):
+  // only a NEW signal past the boundary counts.
+  const result = await assemble(listeners['system-prompt/assemble'], [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ], tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ['bash', 'str_replace_editor'])
+})
+
+test('subagents (delegationDepth > 0) are always promoted', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
+  const result = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session: { id: 'sub', events: [], header: { delegationDepth: 1 } } } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ['bash', 'str_replace_editor'])
+})
+
+test('invalid compactionTools values fail at apply time', () => {
+  assert.throws(() => register({ ...config, compactionTools: [] }), /compactionTools/)
+  assert.throws(() => register({ ...config, compactionTools: ['read', 42] }), /compactionTools/)
 })

--- a/test/zero-tool-bootstrap.test.mjs
+++ b/test/zero-tool-bootstrap.test.mjs
@@ -3,13 +3,14 @@ import test from 'node:test'
 
 import { apply, name } from '../zero-anchored-standard/zero-tool-bootstrap.mjs'
 
-function register() {
-  let listener
+function register(config) {
+  const listeners = {}
+  const hookOptions = {}
   const warns = []
   const ctx = {
-    on(event, callback) {
-      assert.equal(event, 'system-prompt/assemble')
-      listener = callback
+    on(event, callback, options) {
+      listeners[event] = callback
+      hookOptions[event] = options
     },
     logger: {
       warn(message) {
@@ -17,9 +18,9 @@ function register() {
       },
     },
   }
-  apply(ctx)
-  assert.equal(typeof listener, 'function')
-  return { listener, warns }
+  apply(ctx, config)
+  assert.equal(typeof listeners['system-prompt/assemble'], 'function')
+  return { listeners, hookOptions, warns }
 }
 
 function assemble(listener, events, tools, header = {}, id = 's') {
@@ -30,53 +31,157 @@ function assemble(listener, events, tools, header = {}, id = 's') {
   )
 }
 
+function prestep(listener, events, messages, id = 's') {
+  return listener({ agent: { session: { id, events, header: {} } } }, async () => ({ kind: 'enter', messages }))
+}
+
+const userMessage = { id: 'u', content: [{ type: 'text', text: 'hi' }], source: { kind: 'user' } }
+const instructionMessage = { id: 'i', content: [], source: { kind: 'agent-instructions' } }
+const catalogMessage = { id: 'c', content: [], source: { kind: 'skill-catalog' } }
+
 test('exports a diagnostic plugin name', () => {
   assert.equal(name, 'zero-tool-bootstrap')
 })
 
 test('the first top-level request exposes zero tools', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
-  const result = await assemble(listener, [], tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [], tools)
   assert.deepEqual(result.tools, [])
 })
 
-test('a durable assistant message promotes the complete catalog', async () => {
-  const { listener } = register()
+test('a durable assistant message promotes the resident catalog', async () => {
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'grep' }]
-  const result = await assemble(listener, [{ type: 'assistant/message', data: {} }], tools)
-  assert.deepEqual(result.tools, tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools)
+  // Promoted resident: the shells + str_replace_editor + discovery tools —
+  // read/edit/grep are NOT resident (bash covers file work).
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash'])
 })
 
-test('subagents see the full catalog from their first request', async () => {
-  const { listener } = register()
+test('the promoted resident set includes discovery tools and str_replace_editor when available', async () => {
+  const { listeners } = register()
+  const tools = [
+    { name: 'bash' }, { name: 'pwsh' }, { name: 'str_replace_editor' },
+    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' }, { name: 'web_search' },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools)
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), [
+    'bash', 'dev_tool_search', 'pwsh', 'skill_load', 'skill_search', 'str_replace_editor',
+  ])
+})
+
+test('dev_tool_search unlocks tools durably (resume-safe from tool/call events)', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'dev_tool_search' }, { name: 'web_search' }, { name: 'subagent' }]
+  const events = [
+    { type: 'assistant/message', data: {} },
+    { type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["web_search"]}' } },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  const names = result.tools.map((tool) => tool.name)
+  assert.ok(names.includes('web_search'))
+  assert.ok(!names.includes('subagent'))
+})
+
+test('subagents see the resident catalog from their first request', async () => {
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const result = await assemble(listener, [], tools, { delegationDepth: 1 })
-  assert.deepEqual(result.tools, tools)
+  const result = await assemble(listeners['system-prompt/assemble'], [], tools, { delegationDepth: 1 })
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash'])
 })
 
-test('an assembly outside an agent keeps the full catalog', async () => {
-  const { listener } = register()
+test('an assembly outside an agent keeps the resident catalog', async () => {
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }]
-  const result = await listener(undefined, { agent: undefined }, async () => ({ tools }))
-  assert.deepEqual(result.tools, tools)
+  const result = await listeners['system-prompt/assemble'](undefined, { agent: undefined }, async () => ({ tools }))
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash'])
 })
 
 test('promotion is memoized per session id within one process', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const promoted = await assemble(listener, [{ type: 'assistant/message' }], tools, {}, 'memo')
-  assert.deepEqual(promoted.tools, tools)
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, {}, 'memo')
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash'])
   // Same session id, events now empty: the cached decision still promotes.
-  const again = await assemble(listener, [], tools, {}, 'memo')
-  assert.deepEqual(again.tools, tools)
+  const again = await assemble(listeners['system-prompt/assemble'], [], tools, {}, 'memo')
+  assert.deepEqual(again.tools.map((tool) => tool.name), ['bash'])
 })
 
 test('sessions derive promotion independently from their own events', async () => {
-  const { listener } = register()
+  const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const promoted = await assemble(listener, [{ type: 'assistant/message' }], tools, {}, 'a')
-  const fresh = await assemble(listener, [], tools, {}, 'b')
-  assert.deepEqual(promoted.tools, tools)
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, {}, 'a')
+  const fresh = await assemble(listeners['system-prompt/assemble'], [], tools, {}, 'b')
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash'])
   assert.deepEqual(fresh.tools, [])
+})
+
+test('post-compaction falls back to shell plus compactionTools (not the zero-tool anchor)', async () => {
+  const { listeners } = register({ compactionTools: ['read', 'todo_write'] })
+  const tools = [{ name: 'bash' }, { name: 'pwsh' }, { name: 'read' }, { name: 'todo_write' }, { name: 'web_search' }]
+  const events = [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  // All available shells stay; web_search is not in the work set.
+  assert.deepEqual(result.tools.map((tool) => tool.name).sort(), ['bash', 'pwsh', 'read', 'todo_write'])
+})
+
+test('post-compaction without compactionTools stays zero-tool until re-promotion', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }]
+  const events = [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ]
+  const result = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(result.tools, [])
+})
+
+test('a compaction resets promotion; a new message after the boundary re-promotes', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }]
+  const events = [
+    { type: 'assistant/message', seq: 1, data: {} },
+    { type: 'compaction/end', seq: 2 },
+  ]
+  const postCompaction = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(postCompaction.tools, [])
+  // The live harness feeds new events through session/event; emulate that.
+  listeners['session/event']({ id: 's', events }, { type: 'assistant/message', seq: 3, data: {} })
+  const rePromoted = await assemble(listeners['system-prompt/assemble'], events, tools)
+  assert.deepEqual(rePromoted.tools.map((tool) => tool.name), ['bash'])
+})
+
+test('the controlled phase strips skill-catalog and agent-instructions messages', async () => {
+  const { listeners } = register()
+  const decision = await prestep(listeners['agent/pre-step'], [], [userMessage, instructionMessage, catalogMessage])
+  assert.equal(decision.kind, 'enter')
+  assert.deepEqual(decision.messages.map((message) => message.id), ['u'])
+})
+
+test('promoted pre-step keeps every injected context message', async () => {
+  const { listeners } = register()
+  const messages = [userMessage, instructionMessage, catalogMessage]
+  const decision = await prestep(listeners['agent/pre-step'], [{ type: 'assistant/message' }], messages)
+  assert.equal(decision.messages, messages)
+})
+
+test('an empty suppressedContextSources disables the context filter', async () => {
+  const { listeners } = register({ suppressedContextSources: [] })
+  const messages = [userMessage, instructionMessage, catalogMessage]
+  const decision = await prestep(listeners['agent/pre-step'], [], messages)
+  assert.equal(decision.messages, messages)
+})
+
+test('the pre-step strip registers with prepend', () => {
+  const { hookOptions } = register()
+  assert.deepEqual(hookOptions['agent/pre-step'], { prepend: true })
+})
+
+test('invalid compactionTools values fail at apply time', () => {
+  assert.throws(() => register({ compactionTools: [] }), /compactionTools/)
+  assert.throws(() => register({ compactionTools: ['read', 42] }), /compactionTools/)
 })

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -32,19 +32,48 @@
     complete: true
     includeRuntimeContext: false
 
-- id: agent-instructions
-  name: '@deepseek-ai/dsh-agent-instructions'
+# Instruction FILES are NOT injected (replaces dsh-agent-instructions, local
+# addition): the full AGENTS.md/CLAUDE.md digest is a large injected block
+# that perturbs the trajectory even after promotion. Instead, after promotion
+# ONE short hint is injected once per session — "these instruction files
+# exist; read them before acting" — and the model reads the files itself via
+# the filesystem tools when relevant.
+- id: instruction-hint
+  name: ../preset/instruction-hint.mjs
   config:
-    maxBytes: 65536
+    promoteOn: assistant-message
+
+# On-demand tool discovery (the tool-search pattern, local addition): the
+# promoted catalog keeps a minimal resident set; heavier Standard tools
+# (web_search, subagent, workflow, …) are unlocked on demand via
+# dev_tool_search.
+- id: dev-tool-search
+  name: ../preset/dev-tool-search.mjs
 
 # V4 Pro conditions strongly on the API tool catalog. The first top-level
 # model request therefore carries ZERO tools: `anchor-turn` seeds a fixed user
 # message, this bootstrap strips the whole catalog, and the first reasoning
 # chain follows the zero-injection "we" trajectory. After that assistant
-# response is durable, later step assemblies expose every Standard tool
-# registered below. Subagents always see the full catalog.
+# response is durable, later step assemblies narrow to the minimal RESIDENT
+# set (shells + str_replace_editor + the discovery tools + explicitly
+# unlocked tools) instead of the full Standard dump — the post-promotion
+# regression fix. Subagents always see the full catalog.
+#
+# The same phase gate suppresses AUTO-INJECTED context (`suppressedContextSources`,
+# default `['skill-catalog', 'agent-instructions']`) while the session is
+# un-promoted — same reasoning as the anchored variant (issue #6: 0/9 anchored
+# with the skill catalog present vs ~81% without).
+#
+# COMPACTION (local addition): after `compaction/end` the session falls back
+# to the controlled phase — shells + `compactionTools` — until a NEW durable
+# assistant message exists past the boundary (epoch-aware, see
+# preset/compaction-epoch.mjs). The zero-tool anchor applies ONLY to the very
+# first request; post-compaction the model is mid-task and keeps working.
 - id: zero-tool-bootstrap
   name: ./zero-tool-bootstrap.mjs
+  config:
+    suppressedContextSources: [agent-instructions, skill-catalog]
+    compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
 
 # Seed the fixed zero-tool anchor turn when the first user message arrives:
 # the anchor is prepended ahead of it, so the first real model request has no
@@ -85,6 +114,29 @@
   config:
     sampleOverCapGlobResults: false
 
+# The Minimal preset's second tool: `str_replace_editor` over a bare local
+# filesystem, byte-identical in configuration to the official `minimal`
+# preset's `filesystem` group (and to the anchored preset's copy). It is part
+# of the promoted resident set. The editor's own realm shadows the host's
+# sandboxed `fs` provider only inside this group, so the standard `read`/
+# `write`/`edit` tools keep the sandboxed fs while the editor uses the local
+# one.
+- id: bootstrap-filesystem
+  name: cordis:group
+  group: true
+  isolate:
+    fs: true
+  config:
+    - id: fs-local
+      name: '@deepseek-ai/dsh-fs-local'
+      config:
+        cwd: !!js process.env.DSH_CWD ?? process.cwd()
+
+    - id: str-replace-editor
+      name: '@deepseek-ai/dsh-tool-str-replace-editor'
+      config:
+        maxOutputChars: 16000
+
 # ── background jobs ────────────────────────────────────────────────────────
 
 # Only the model-facing controls. The task REGISTRY stays on the host plane:
@@ -101,14 +153,17 @@
 
 # The skill REGISTRY lives in the host composition and is layered per scope:
 # these rows register into THIS preset's layer of it, so they need no realm.
-# `skill-filesystem` contributes local-root discovery for agents on this preset, and
-# `tool-skill` gives them the catalog and loader; the merged catalog also
-# carries whatever the deployment registered globally (repository plugins).
+# `skill-filesystem` contributes local-root discovery for agents on this
+# preset. The full skill CATALOG injection (`dsh-tool-skill`, the ~9KB
+# `<available_skills>` reminder) is REMOVED (local addition): it perturbs the
+# trajectory (issue #6). Instead `skill-search` exposes two small on-demand
+# tools — skill_search (list matching summaries) and skill_load (inject one
+# skill's full instructions) — the tool-search pattern.
 - id: skill-filesystem
   name: '@deepseek-ai/dsh-skill-filesystem'
 
-- id: tool-skill
-  name: '@deepseek-ai/dsh-tool-skill'
+- id: skill-search
+  name: ../preset/skill-search.mjs
 
 # ── goals ───────────────────────────────────────────────────────────────────
 

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -102,6 +102,18 @@
   name: '@deepseek-ai/dsh-tool-pwsh'
   disabled: !!js process.platform !== 'win32'
 
+# Windows-only `bash` tool (see preset/custom-bash.mjs): the official bash
+# needs a PTY, and DSH's PTY backend is linux/darwin-only. This row presents
+# the SAME tool name (`bash`) with a Minimal-compatible description but spawns
+# Git Bash through the ordinary cross-platform subprocess seam. `bashPath`
+# defaults to `bash` on PATH; point it at Git Bash explicitly when the WSL
+# shim would otherwise be picked up.
+- id: custom-bash
+  name: ../preset/custom-bash.mjs
+  disabled: !!js process.platform !== 'win32'
+  config:
+    bashPath: 'C:\Program Files\Git\bin\bash.exe'
+
 # ── filesystem ──────────────────────────────────────────────────────────────
 
 # Both register into the host `tools` registry and provide nothing, so

--- a/zero-anchored-standard/zero-tool-bootstrap.mjs
+++ b/zero-anchored-standard/zero-tool-bootstrap.mjs
@@ -1,13 +1,40 @@
 /**
  * Zero-tool bootstrap — keep the FIRST top-level model request on an EMPTY
- * tool surface, then expose the full preset catalog once the anchor turn has
- * produced its first durable assistant message.
+ * tool surface, free of auto-injected workspace/skill context, then narrow
+ * the catalog to a minimal RESIDENT set once the anchor turn has produced its
+ * first durable assistant message.
  *
  * This is the extra test mode behind `zero-anchored-standard`: the anchor
  * plugin seeds a fixed user message and this filter strips the whole catalog,
  * so the first real request follows the zero-injection "we" trajectory. After
- * that assistant response is durable, every later request sees the full
- * Standard catalog.
+ * that assistant response is durable, later requests see the resident
+ * catalog.
+ *
+ * WHY RESIDENT (local addition, user-measured): the promoted phase does NOT
+ * dump the whole Standard catalog at once — that dump pulls the trajectory
+ * back to standard-like behavior (measured post-promotion regression: a flood
+ * of `let me` first-lines). Instead the catalog narrows to the shells +
+ * `str_replace_editor` + the three discovery tools (`dev_tool_search`,
+ * `skill_search`, `skill_load`) plus whatever the model explicitly unlocked
+ * via `dev_tool_search`. Heavier Standard tools (web_search, subagent,
+ * workflow, …) are one `dev_tool_search` call away; unlocked names are
+ * derived from durable `tool/call` events, so resume and reload keep them.
+ *
+ * COMPACTION (local addition): a compaction rewrites the whole surface, so the
+ * first post-compaction request is a "second first request". Promotion is
+ * epoch-aware (see preset/compaction-epoch.mjs): after `compaction/end` the
+ * session falls back to a controlled phase — the shells plus `compactionTools`
+ * (a core work set, default none) — until a NEW durable assistant message
+ * exists past that boundary. The zero-tool anchor applies ONLY to the very
+ * first request: after a compaction the model is mid-task and needs to keep
+ * working, but still faces a small catalog instead of the full Standard set.
+ *
+ * Injected reminders (the AGENTS.md digest and the `<available_skills>`
+ * catalog, source kinds `agent-instructions` / `skill-catalog`) are stripped
+ * during the controlled phase — same reasoning as the anchored variant
+ * (issue #6: with the skill catalog present the anchor did not reproduce at
+ * all, 0/9). `suppressedContextSources` is configurable; an empty array
+ * disables the context filter while keeping the tool bootstrap.
  *
  * Robustness:
  *  - Promotion decisions are memoized per session id for this process; the
@@ -18,16 +45,53 @@
  *    so a bug can never brick every request of a session.
  */
 
+import { createEpochPromotion } from '../preset/compaction-epoch.mjs'
+
 /** Cordis plugin name used by loader diagnostics. */
 export const name = 'zero-tool-bootstrap'
 
-/** Prompt assembly must exist before this request filter can register. */
-export const inject = ['systemPrompt']
+/**
+ * Deliberately NO inject list: the listeners only touch services at event
+ * time, and the pre-step strip below registers with `prepend: true` so it
+ * stays the OUTERMOST waterfall transform (see the anchored copy for the full
+ * registration-order reasoning).
+ */
+export const inject = []
 
-/** Register the per-session bootstrap filter. */
-export function apply(ctx) {
-  /** Sessions already promoted in this process. Promotion is append-only, so a Set is sound. */
-  const promoted = new Set()
+/** Same automatic injections the anchored variant strips by default. */
+const DEFAULT_SUPPRESSED_SOURCES = ['skill-catalog', 'agent-instructions']
+
+/** Shell candidates (the anchored preset's custom-bash registers `bash`; pwsh is Windows standard). */
+const SHELLS = ['bash', 'pwsh']
+
+/** Discovery tools always resident after promotion (the tool-search pattern). */
+const RESIDENT_DISCOVERY_TOOLS = ['dev_tool_search', 'skill_search', 'skill_load']
+
+function stringListOrEmpty(value, field) {
+  if (value === undefined) return []
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be a non-empty array of non-empty strings`)
+  }
+  return [...new Set(value)]
+}
+
+function sourceList(value, field, fallback) {
+  if (value === undefined) return new Set(fallback)
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be an array of non-empty strings`)
+  }
+  return new Set(value)
+}
+
+/** Register the per-session bootstrap filters. */
+export function apply(ctx, config) {
+  // Core work set exposed after a compaction, before re-promotion.
+  const compactionTools = stringListOrEmpty(config?.compactionTools, 'compactionTools')
+  const suppressedSources = sourceList(config?.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+
+  const promotion = createEpochPromotion(['assistant/message'])
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
   let warned = false
   const warnOnce = (message) => {
     if (warned) return
@@ -40,31 +104,96 @@ export function apply(ctx) {
   }
 
   /**
-   * Whether the session has reached the promoted (full-catalog) phase.
-   * @param agent - the assembly context's agent, or undefined outside an agent.
+   * Tool names the model explicitly unlocked via `dev_tool_search` for one
+   * session. Derived from durable `tool/call` events so resume/reload keeps
+   * them. The event's `arguments` is the raw JSON string the model produced;
+   * we parse it defensively and read the `toolNames` array.
    */
-  const isPromoted = (agent) => {
-    if (agent === undefined) return true
-    const session = agent.session
-    if (session === undefined) return true
-    // Subagents keep their full catalog from their very first request.
-    if ((session.header.delegationDepth ?? 0) > 0) return true
-    if (promoted.has(session.id)) return true
-    const hit = session.events.some((event) => event.type === 'assistant/message')
-    if (hit) promoted.add(session.id)
-    return hit
+  const unlockedFor = (session) => {
+    const unlocked = new Set()
+    if (session === undefined || !Array.isArray(session.events)) return unlocked
+    for (const event of session.events) {
+      if (event.type !== 'tool/call') continue
+      if (event.data?.name !== 'dev_tool_search') continue
+      let args
+      try {
+        args = JSON.parse(event.data.arguments)
+      } catch {
+        continue
+      }
+      if (args === null || typeof args !== 'object' || Array.isArray(args)) continue
+      const names = args.toolNames
+      if (Array.isArray(names)) for (const name of names) if (typeof name === 'string' && name.length > 0) unlocked.add(name)
+    }
+    return unlocked
   }
 
   ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
     // Downstream errors propagate untouched; only this filter's own logic is guarded.
     const assembled = await next()
     try {
-      if (isPromoted(context.agent)) return assembled
-      return { ...assembled, tools: [] }
+      const status = promotion.status(context.agent)
+      if (status.promoted) {
+        // PROMOTED: keep the minimal resident set — the shells +
+        // str_replace_editor + the discovery tools + whatever the model
+        // explicitly unlocked via dev_tool_search — instead of dumping the
+        // whole Standard catalog at once (the post-promotion regression fix).
+        const available = new Set(assembled.tools.map((tool) => tool.name))
+        const keep = new Set([
+          ...SHELLS.filter((name) => available.has(name)),
+          'str_replace_editor', ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session),
+        ])
+        return {
+          ...assembled,
+          tools: assembled.tools.filter((tool) => keep.has(tool.name)),
+        }
+      }
+      const { boundary } = status
+      // First request (no compaction yet): zero tools, the "we" anchor.
+      if (boundary < 0) return { ...assembled, tools: [] }
+      // Post-compaction: core work set so mid-task work can continue.
+      if (compactionTools.length === 0) return { ...assembled, tools: [] }
+      const available = new Set(assembled.tools.map((tool) => tool.name))
+      const selectedShells = SHELLS.filter((toolName) => available.has(toolName))
+      const missing = compactionTools.filter((toolName) => !available.has(toolName))
+      if (selectedShells.length === 0 || missing.length > 0) {
+        warnOnce(
+          `${name}: expected at least one phase shell and every phase tool; `
+          + `shells=${JSON.stringify(selectedShells)}, missing=${JSON.stringify(missing)} — `
+          + 'bootstrap disabled, full catalog exposed',
+        )
+        return assembled
+      }
+      const keep = new Set([...selectedShells, ...compactionTools])
+      return {
+        ...assembled,
+        tools: assembled.tools.filter((tool) => keep.has(tool.name)),
+      }
     } catch (error) {
       // A filter bug must never brick a session: degrade to the full catalog.
       warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
       return assembled
     }
   })
+
+  // Strip injected reminders (skill catalog, AGENTS.md) during the controlled
+  // phase. Same registration discipline as the anchored variant: `prepend`
+  // keeps the strip the OUTERMOST transform of the agent/pre-step waterfall.
+  ctx.on('agent/pre-step', async ({ agent }, next) => {
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    try {
+      if (promotion.status(agent).promoted || suppressedSources.size === 0) return decision
+      if (!Array.isArray(decision.messages)) return decision
+      const kept = decision.messages.filter((message) => {
+        const kind = message?.source?.kind
+        return typeof kind !== 'string' || !suppressedSources.has(kind)
+      })
+      return kept.length === decision.messages.length ? decision : { ...decision, messages: kept }
+    } catch (error) {
+      // A filter bug must never eat context: degrade to keeping every message.
+      warnOnce(`${name}: pre-step context filter failed, keeping injected context: ${String((error && error.message) || error)}`)
+      return decision
+    }
+  }, { prepend: true })
 }


### PR DESCRIPTION
Implements the Windows half of issue #19: PTY-free custom-bash so the Minimal bootstrap pair works on win32 (DSH PTY backend is linux/darwin-only). Platform-exclusive rows in both presets; mocked-subprocess tests. Depends on PR 1 (same YAML files) — merge PR 1 first.