### PR TITLE
feat: add whoami-standard preset (whoami anchor turn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,48 @@ cp -R zero-anchored-standard "$dsh_home/.agent-presets/zero-anchored-standard"
 Restart DeepSeek Harness, create a blank session, select **Zero-Anchored
 Standard (experimental)**, then send your first message.
 
+## Whoami Standard (experimental)
+
+A usability-oriented variant of the zero-tool anchor idea: the first turn is a
+natural self-introduction prompt instead of a fixed test message, and the
+user's real first message is deferred to the next turn. Whatever the user types
+first, the session warms up exactly one round and everything is ready when the
+real message is processed:
+
+1. When the user sends their first message, the `whoami-turn` plugin prepends a
+   fixed user message — "你是谁" (who are you) — ahead of it in the `next-turn`
+   inbox queue.
+2. dsh claims exactly ONE `next-turn` message per turn, so the first model
+   request sees only the anchor on an EMPTY tool surface and replies with a
+   self-introduction; that reply is the promotion signal.
+3. The real message is claimed by the NEXT turn, with the promoted resident
+   catalog (shells, `str_replace_editor`, the discovery tools) already
+   unlocked — heavier Standard tools are one `dev_tool_search` away.
+
+The anchor text is configurable via the `whoami-turn` row's `text` option
+(default "你是谁"). Anchoring on the first message — not session creation —
+keeps the blank-session preset switcher usable; subagents always see the full
+catalog. The trade-off is one extra model call per session: the anchor turn is
+always taken, even when the first message is urgent.
+
+The preset shares plugin modules with the anchored `preset/` directory via
+`../preset/` references, so install that directory as well (see the Install
+section above).
+
+Install as a separate preset id:
+
+```sh
+dsh_home="${DSH_HOME:-$HOME/.dsh}"
+mkdir -p "$dsh_home/.agent-presets"
+test ! -e "$dsh_home/.agent-presets/whoami-standard"
+cp -R whoami-standard "$dsh_home/.agent-presets/whoami-standard"
+```
+
+Restart DeepSeek Harness, create a blank session, select **Whoami Standard
+(experimental)**, then send your first message — the self-introduction round
+runs first, and your message is answered with the full tooling on the next
+turn.
+
 ## Official ecosystem guidance
 
 DeepSeek currently asks community plugin authors to publish plugins in their own

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,6 +181,38 @@ cp -R zero-anchored-standard "$dsh_home/.agent-presets/zero-anchored-standard"
 重启 DeepSeek Harness，新建空白会话，选择 **Zero-Anchored Standard
 (experimental)**，然后发送第一条消息。
 
+## Whoami Standard（实验）
+
+"零工具锚定"思路的易用性变体：首轮不是固定测试语，而是一句自然的自我介绍
+提示（"你是谁"），用户的第一条真实消息自动推迟到下一轮。无论你第一条发什么，
+会话都会先热身一轮，等你真实的消息进来时一切就绪：
+
+1. 用户发出第一条消息时，`whoami-turn` 插件把固定消息——"你是谁"——prepend 到
+   `next-turn` 收件队列、排在真实消息前面；
+2. dsh 每轮只消费一条 `next-turn` 消息，因此第一个模型请求只看到锚定消息、
+   携带 **0 个工具**，模型回复自我介绍，该回复即晋升信号；
+3. 下一轮才轮到真实消息，此时晋升后的 resident 目录（shell、str_replace_editor、
+   发现类工具）已解锁，重型 Standard 工具一次 `dev_tool_search` 即可取用。
+
+锚定文本可通过 `whoami-turn` 行的 `text` 配置（默认"你是谁"）。锚定发生在第一条
+消息到达时而非会话创建时，新建会话仍可先切换模式；子 agent 始终看到完整目录。
+代价是每个会话固定多一次模型调用——即使第一条消息很紧急也会先跑自我介绍轮。
+
+该预设通过 `../preset/` 引用与 anchored 的 `preset/` 目录共享插件模块，安装时
+请一并安装该目录（见上文"安装"章节）。
+
+以独立 preset id 安装：
+
+```sh
+dsh_home="${DSH_HOME:-$HOME/.dsh}"
+mkdir -p "$dsh_home/.agent-presets"
+test ! -e "$dsh_home/.agent-presets/whoami-standard"
+cp -R whoami-standard "$dsh_home/.agent-presets/whoami-standard"
+```
+
+重启 DeepSeek Harness，新建空白会话，选择 **Whoami Standard (experimental)**，
+然后发送第一条消息——自我介绍轮先跑，你的消息在下一轮带着完整工具被回答。
+
 ## 官方生态要求
 
 DeepSeek 当前建议社区作者把插件放在自己的 GitHub 项目中，并为仓库添加

--- a/test/whoami-turn.test.mjs
+++ b/test/whoami-turn.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { ANCHOR_TEXT, apply, name } from '../whoami-standard/whoami-turn.mjs'
+
+function register(config = {}) {
+  let listener
+  const ctx = {
+    on(event, callback) {
+      assert.equal(event, 'agent/inbox/inserted')
+      listener = callback
+    },
+  }
+  apply(ctx, config)
+  assert.equal(typeof listener, 'function')
+  return listener
+}
+
+function agent({ depth = 0, events = [] } = {}) {
+  const prepends = []
+  const subject = {
+    session: { header: { delegationDepth: depth }, events },
+    inbox: {
+      prepend(target, message) {
+        prepends.push({ target, message })
+      },
+    },
+  }
+  return { subject, prepends }
+}
+
+test('exports a diagnostic plugin name and default anchor text', () => {
+  assert.equal(name, 'whoami-turn')
+  assert.equal(typeof ANCHOR_TEXT, 'string')
+  assert.ok(ANCHOR_TEXT.length > 0)
+})
+
+test('the first user message prepends the default anchor ahead of it', () => {
+  const listener = register()
+  const { subject, prepends } = agent()
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 1)
+  assert.equal(prepends[0].target, 'next-turn')
+  assert.equal(prepends[0].message.role, 'user')
+  assert.equal(prepends[0].message.content[0].text, ANCHOR_TEXT)
+  assert.equal(prepends[0].message.source.plugin, 'whoami-turn')
+})
+
+test('config text overrides the default anchor', () => {
+  const custom = 'Who are you?'
+  const listener = register({ text: custom })
+  const { subject, prepends } = agent()
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends[0].message.content[0].text, custom)
+})
+
+test('plugin-sourced messages never re-anchor', () => {
+  const listener = register()
+  const { subject, prepends } = agent()
+  listener({ agent: subject, message: { source: { kind: 'plugin', plugin: 'whoami-turn' } } })
+  assert.equal(prepends.length, 0)
+})
+
+test('sessions with a prior user message are not anchored again', () => {
+  const listener = register()
+  const { subject, prepends } = agent({ events: [{ type: 'user/message' }] })
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 0)
+})
+
+test('subagents are never anchored', () => {
+  const listener = register()
+  const { subject, prepends } = agent({ depth: 1 })
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 0)
+})

--- a/whoami-standard/agent.cordis.yml
+++ b/whoami-standard/agent.cordis.yml
@@ -1,0 +1,348 @@
+# The `whoami-standard` experimental preset: Standard capabilities with the
+# Minimal mode system-prompt condition used by the V4 trajectory evaluation,
+# plus a whoami anchor turn.
+#
+# Whatever the user's first message is, the first model request sees only the
+# fixed "你是谁" prompt on an EMPTY tool surface; the real message is deferred
+# to the next turn, when the promoted resident catalog is already unlocked.
+#
+# This file is an AGENT-PLANE composition. The roster mounts it ONCE under a
+# standing scope; every session naming it joins by scope parentage, so the
+# tools and prompt sections registered here cover each joined agent while a
+# session's own state stays keyed per Session/Agent inside the plugins. The
+# host composition (`base.cordis.yml` + `web.cordis.yml`) keeps everything a
+# preset must not own: the registries themselves, the sandbox and approval
+# stack, persistence, and the model route.
+#
+# A service row here MUST sit inside a group carrying an `isolate` realm.
+# Without one it publishes into the root realm, where it is process-global —
+# another preset publishing the same name collides, and a host reader would
+# resolve one preset's instance for every session; `dsh-agent-presets` rejects
+# that at mount. `true` means an entry-local realm: this standing mount's own
+# private instance, apart from every other preset's. (A shared label does NOT
+# pool instances — `provide()` throws on the second registration under the
+# same realm symbol; labels join REALMS, and are not what this file needs.)
+
+# ── identity ────────────────────────────────────────────────────────────────
+
+# Keep this text byte-identical to the Minimal preset. `complete` prevents the
+# Harness identity and per-tool guidance from changing the system prompt, while
+# runtime-context suppression leaves task and repository rules to user messages
+# and explicit file reads. Tool schemas and their runtime enforcement remain.
+- id: persona
+  name: '@deepseek-ai/dsh-persona'
+  config:
+    text: You are a helpful software engineer assistant.
+    complete: true
+    includeRuntimeContext: false
+
+# Instruction FILES are NOT injected (replaces dsh-agent-instructions, local
+# addition): the full AGENTS.md/CLAUDE.md digest is a large injected block
+# that perturbs the trajectory even after promotion. Instead, after promotion
+# ONE short hint is injected once per session — "these instruction files
+# exist; read them before acting" — and the model reads the files itself via
+# the filesystem tools when relevant.
+- id: instruction-hint
+  name: ../preset/instruction-hint.mjs
+  config:
+    promoteOn: assistant-message
+
+# On-demand tool discovery (the tool-search pattern, local addition): the
+# promoted catalog keeps a minimal resident set; heavier Standard tools
+# (web_search, subagent, workflow, …) are unlocked on demand via
+# dev_tool_search.
+- id: dev-tool-search
+  name: ../preset/dev-tool-search.mjs
+
+# V4 Pro conditions strongly on the API tool catalog. The first top-level
+# model request therefore carries ZERO tools: `whoami-turn` seeds the fixed
+# "你是谁" user message, this bootstrap strips the whole catalog, and the
+# model's self-introduction reply is the promotion signal. After that
+# assistant response is durable, later step assemblies narrow to the minimal
+# RESIDENT set (shells + str_replace_editor + the discovery tools + explicitly
+# unlocked tools) instead of the full Standard dump — the post-promotion
+# regression fix. Subagents always see the full catalog.
+#
+# The same phase gate suppresses AUTO-INJECTED context (`suppressedContextSources`,
+# default `['skill-catalog', 'agent-instructions']`) while the session is
+# un-promoted — same reasoning as the anchored variant (issue #6: 0/9 anchored
+# with the skill catalog present vs ~81% without).
+#
+# COMPACTION (local addition): after `compaction/end` the session falls back
+# to the controlled phase — shells + `compactionTools` — until a NEW durable
+# assistant message exists past the boundary (epoch-aware, see
+# preset/compaction-epoch.mjs). The zero-tool anchor applies ONLY to the very
+# first request; post-compaction the model is mid-task and keeps working.
+- id: zero-tool-bootstrap
+  name: ./zero-tool-bootstrap.mjs
+  config:
+    suppressedContextSources: [agent-instructions, skill-catalog]
+    compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
+
+# Seed the whoami anchor turn when the first user message arrives: the anchor
+# is prepended to the `next-turn` inbox queue ahead of the real message, and
+# dsh claims exactly ONE `next-turn` message per turn, so the first real model
+# request sees only "你是谁" with no tools, while the real input is claimed by
+# the NEXT turn — with the promoted resident catalog already unlocked.
+# Anchoring on first message — not session creation — keeps the blank-session
+# preset switcher usable. The anchor text is configurable via `text`.
+- id: whoami-turn
+  name: ./whoami-turn.mjs
+  config:
+    text: 你是谁
+
+# ── shell ───────────────────────────────────────────────────────────────────
+
+# `shell-env` stays in the HOST composition: `apps/cli/src/web.ts` injects it to
+# publish `DSH_WEB_URL`/`DSH_WEB_MODE`, and a host row that injects a service is
+# the criterion for host-plane ownership — injection resolves before any session
+# exists, so there is no agent to key by. Behind a preset realm those variables
+# never reached the model's shell at all. Both shell tools consume the host
+# registry from here; their executors (`bash-sandbox`/`pwsh-sandbox`) are
+# host-plane too.
+- id: tool-bash
+  name: '@deepseek-ai/dsh-tool-bash'
+  disabled: !!js process.platform === 'win32'
+
+- id: tool-pwsh
+  name: '@deepseek-ai/dsh-tool-pwsh'
+  disabled: !!js process.platform !== 'win32'
+
+# Windows-only `bash` tool (see preset/custom-bash.mjs): the official bash
+# needs a PTY, and DSH's PTY backend is linux/darwin-only. This row presents
+# the SAME tool name (`bash`) with a Minimal-compatible description but spawns
+# Git Bash through the ordinary cross-platform subprocess seam. `bashPath`
+# defaults to `bash` on PATH; point it at Git Bash explicitly when the WSL
+# shim would otherwise be picked up.
+- id: custom-bash
+  name: ../preset/custom-bash.mjs
+  disabled: !!js process.platform !== 'win32'
+  config:
+    bashPath: 'C:\Program Files\Git\bin\bash.exe'
+
+# ── filesystem ──────────────────────────────────────────────────────────────
+
+# Both register into the host `tools` registry and provide nothing, so
+# they need no realm. The `fs` service and its policy stay in the host.
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+- id: tool-fs-search
+  name: '@deepseek-ai/dsh-tool-fs-search'
+  config:
+    sampleOverCapGlobResults: false
+
+# The Minimal preset's second tool: `str_replace_editor` over a bare local
+# filesystem, byte-identical in configuration to the official `minimal`
+# preset's `filesystem` group (and to the anchored preset's copy). It is part
+# of the promoted resident set. The editor's own realm shadows the host's
+# sandboxed `fs` provider only inside this group, so the standard `read`/
+# `write`/`edit` tools keep the sandboxed fs while the editor uses the local
+# one.
+- id: bootstrap-filesystem
+  name: cordis:group
+  group: true
+  isolate:
+    fs: true
+  config:
+    - id: fs-local
+      name: '@deepseek-ai/dsh-fs-local'
+      config:
+        cwd: !!js process.env.DSH_CWD ?? process.cwd()
+
+    - id: str-replace-editor
+      name: '@deepseek-ai/dsh-tool-str-replace-editor'
+      config:
+        maxOutputChars: 16000
+
+# ── background jobs ────────────────────────────────────────────────────────
+
+# Only the model-facing controls. The task REGISTRY stays on the host plane:
+# its producers sit outside any realm this file could put it in — `tool-bash`
+# above resolves it with `ctx.get`, and an entry-local realm here is invisible
+# to every sibling row, so `run_in_background` would answer "background jobs
+# unavailable" while these controls sat in the catalog. The registry is keyed by
+# owning agent anyway, so one host instance serves every session. What a preset
+# chooses is whether its agent can collect and stop background work at all.
+- id: tool-jobs
+  name: '@deepseek-ai/dsh-tool-jobs'
+
+# ── skills ──────────────────────────────────────────────────────────────────
+
+# The skill REGISTRY lives in the host composition and is layered per scope:
+# these rows register into THIS preset's layer of it, so they need no realm.
+# `skill-filesystem` contributes local-root discovery for agents on this
+# preset. The full skill CATALOG injection (`dsh-tool-skill`, the ~9KB
+# `<available_skills>` reminder) is REMOVED (local addition): it perturbs the
+# trajectory (issue #6). Instead `skill-search` exposes two small on-demand
+# tools — skill_search (list matching summaries) and skill_load (inject one
+# skill's full instructions) — the tool-search pattern.
+- id: skill-filesystem
+  name: '@deepseek-ai/dsh-skill-filesystem'
+
+- id: skill-search
+  name: ../preset/skill-search.mjs
+
+# ── goals ───────────────────────────────────────────────────────────────────
+
+# Only the model-facing tool. The goal SERVICE, its session driver, and the
+# `/goal` command stay on the host plane: the Gateway serves the goal domain as
+# Remote endpoints whose receiver comes from a generated descriptor, so it
+# resolves `goals` on the host and an entry-local realm here would hide it. The
+# registry is keyed by session anyway, so one host instance serves every
+# session. What a preset chooses is whether its agent can call the goal tool.
+- id: tool-goal
+  name: '@deepseek-ai/dsh-tool-goal'
+
+# ── plan mode ───────────────────────────────────────────────────────────────
+
+# Plan state is per-agent by nature, so an entry-local realm is not a
+# workaround here — it is the correct lifetime.
+- id: planning
+  name: cordis:group
+  group: true
+  isolate:
+    planMode: true
+  config:
+    - id: plan-mode
+      name: '@deepseek-ai/dsh-plan-mode'
+      config:
+        section: |
+              You are in plan mode. Stay in plan mode until exit_plan_mode succeeds or the user switches the session mode. Imperative language to implement changes means plan the implementation, not execute it. A user's conversational agreement — including an answer confirming something you asked — approves nothing and does not end plan mode; fold the confirmed decision into the plan and submit it through exit_plan_mode.
+
+              Explore first. Use non-mutating reads, searches, static analysis, and checks to ground the plan in the actual repository. Do not edit or write files, change configuration, run formatters or code generation that rewrites tracked files, commit, or otherwise carry out the plan. Prefer existing functions and patterns over new machinery.
+
+              The tool catalog stays the same across modes for request-cache stability. These plan-mode rules override any later tool description or guidance that suggests using mutation tools; those tools remain listed to keep the tool catalog unchanged. Do not use todo_write to track this planning phase: it tracks implementation after an approved plan, while the plan itself belongs in exit_plan_mode.
+
+              Resolve discoverable facts by inspection. Use ask_user_question only for user-owned choices or material ambiguity that inspection cannot answer. Do not ask the user where code lives or how current behavior works when you can find out.
+
+              Make the plan decision-complete: state the goal and success criteria; group implementation changes by subsystem; identify public API, schema, and data-flow changes; cover edge cases, failure modes, tests, acceptance criteria, and explicit assumptions. Keep it concise enough to review but detailed enough that another engineer can implement it without making design decisions.
+
+              When ready, call exit_plan_mode with the complete plan markdown, starting with a # title. Make exit_plan_mode the only and final tool call in that assistant response: it presents the plan for approval, and implementation begins only in a later step after approval. Do not paste the final plan as a plain reply or ask "should I proceed?" through prose or ask_user_question. If review rejects it, incorporate the feedback and present again. If the review channel is unavailable or aborted, stay in plan mode and ask the user to switch modes manually; do not proceed with implementation.
+
+# ── compaction ──────────────────────────────────────────────────────────────
+
+# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
+# share this realm rather than sit outside it.
+#
+# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
+# plane, and the rows here resolve that one instance. It takes no configuration,
+# keys every fold by Session, and owns the context-meter projection units the
+# browser reads for every session — behind a realm those units would come and go
+# with whichever presets happen to be mounted. What a preset chooses is whether
+# its agent compacts at all, which is `compaction-basic` below.
+- id: compaction
+  name: cordis:group
+  group: true
+  isolate:
+    compaction: true
+    toolResultPruner: true
+  config:
+    - id: compaction-basic
+      name: '@deepseek-ai/dsh-compaction-basic'
+
+    - id: command-compact
+      name: '@deepseek-ai/dsh-command-compact'
+
+    - id: tool-result-pruner
+      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
+      config:
+        thresholdChars: 8192
+        headChars: 4096
+        tailChars: 1024
+
+# ── delegation and workflows ────────────────────────────────────────────────
+
+# The `subagents` registry and its spawn/fork backends live in the HOST
+# composition: the registry is a process singleton whose cross-session queries
+# the api-proxy serves to the browser, and a provider name may only be
+# registered once. This preset contributes the delegation TOOLS, which resolve
+# that host registry.
+#
+# `workflows` is different — nothing outside an agent reads it — so every row
+# that reaches it shares one entry-local realm here, and a consumer left
+# outside would resolve a host registry this preset does not populate.
+#
+# `tool-subagent-report` is host-plane for the same reason as the registry,
+# not because a preset may not want it: it registers a CONTINUABLE SETUP on
+# that singleton rather than a tool this agent calls, and the setup list is
+# not scope-aware — one copy per mounted preset means every child gets
+# `report` registered once per live session, which throws on the second.
+- id: delegation
+  name: cordis:group
+  group: true
+  isolate:
+    workflowEngine: true
+  config:
+    - id: tool-subagent-control
+      name: '@deepseek-ai/dsh-tool-subagent-control'
+
+    - id: tool-subagent-list-agents
+      name: '@deepseek-ai/dsh-tool-subagent-control/list-agents'
+
+    - id: tool-subagent
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: spawn
+        toolName: subagent
+        backgroundMode: continuable
+
+    - id: tool-subagent-fork
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: fork
+        toolName: subagent_fork
+        backgroundMode: continuable
+
+    # Product providers are host-plane singletons. Copy this preset, then
+    # remove `disabled` from either ordinary tool row to expose that product
+    # only to agents composed from the copy.
+    - id: tool-subagent-codex
+      name: '@deepseek-ai/dsh-tool-subagent'
+      disabled: true
+      config:
+        provider: codex
+        toolName: subagent_codex
+        enableRunInBackground: false
+        maxDepth: provider-managed
+
+    - id: tool-subagent-claude-code
+      name: '@deepseek-ai/dsh-tool-subagent'
+      disabled: true
+      config:
+        provider: claude-code
+        toolName: subagent_claude_code
+        enableRunInBackground: false
+        maxDepth: provider-managed
+
+    - id: workflow-worker-thread
+      name: '@deepseek-ai/dsh-workflow-worker-thread'
+      config:
+        provider: spawn
+
+    - id: tool-workflow
+      name: '@deepseek-ai/dsh-tool-workflow'
+
+    - id: tool-ralph
+      name: '@deepseek-ai/dsh-tool-ralph'
+      config:
+        subagentProvider: spawn
+        maxRounds: 64
+
+# ── remaining model-facing rows ─────────────────────────────────────────────
+
+- id: tool-ask-user
+  name: '@deepseek-ai/dsh-tool-ask-user'
+
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+# The `web` service and its search provider stay in the host composition; only
+# the model-facing tool is per-session.
+- id: tool-web
+  name: '@deepseek-ai/dsh-tool-web'
+  config:
+    fetch: false
+    searchTimeoutMs: 60000

--- a/whoami-standard/preset.yml
+++ b/whoami-standard/preset.yml
@@ -1,0 +1,3 @@
+name: Whoami Standard (experimental)
+description: Seed one fixed "你是谁" (who are you) self-introduction turn on an empty tool surface, then let the user's first real message proceed on the next turn with the promoted resident catalog unlocked.
+order: 7

--- a/whoami-standard/whoami-turn.mjs
+++ b/whoami-standard/whoami-turn.mjs
@@ -1,0 +1,55 @@
+/**
+ * Whoami anchor turn — seed ONE self-introduction round ahead of the user's
+ * very first real message.
+ *
+ * The anchor is PREPENDED to the `next-turn` inbox queue ahead of the real
+ * message, and dsh claims exactly ONE `next-turn` message per turn, so the
+ * first real model request is the fixed "who are you" prompt on an EMPTY tool
+ * surface (see zero-tool-bootstrap.mjs), while the user's actual message stays
+ * queued and is claimed by the NEXT turn — by then the bootstrap has promoted
+ * and the full Standard catalog (including the search MCP) is unlocked.
+ *
+ * Anchoring on the first user message — instead of at session creation — keeps
+ * the blank-session preset switcher usable before the user types anything.
+ *
+ * Durability is free: the prepend goes through `agent/inbox/spliced` event
+ * persistence, so a crash between the anchor and the real message resumes the
+ * queue in order, and the inbox replay does not fire `inserted` notifications,
+ * so the anchor is never re-injected.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'whoami-turn'
+
+/** Default anchor text shown to the model in the synthetic first user turn. */
+export const ANCHOR_TEXT = '你是谁'
+
+/** Only top-level fresh sessions (no prior user message) get the anchor turn. */
+function isFreshTopLevel(agent) {
+  if ((agent.session.header.delegationDepth ?? 0) > 0) return false
+  return !agent.session.events.some((event) => event.type === 'user/message')
+}
+
+/** Register the first-message whoami anchor injection. */
+export function apply(ctx, config) {
+  const text = typeof config.text === 'string' && config.text.length > 0
+    ? config.text
+    : ANCHOR_TEXT
+
+  ctx.on('agent/inbox/inserted', ({ agent, message }) => {
+    if (!isFreshTopLevel(agent)) return
+    // Never re-anchor on plugin-sourced messages (including our own anchor).
+    if (message.source?.kind === 'plugin') return
+    agent.inbox.prepend('next-turn', {
+      id: crypto.randomUUID(),
+      role: 'user',
+      content: [{ type: 'text', text }],
+      source: {
+        kind: 'plugin',
+        plugin: 'whoami-turn',
+        form: 'notice',
+        summary: 'whoami anchor turn',
+      },
+    })
+  })
+}

--- a/whoami-standard/zero-tool-bootstrap.mjs
+++ b/whoami-standard/zero-tool-bootstrap.mjs
@@ -1,0 +1,199 @@
+/**
+ * Zero-tool bootstrap — keep the FIRST top-level model request on an EMPTY
+ * tool surface, free of auto-injected workspace/skill context, then narrow
+ * the catalog to a minimal RESIDENT set once the anchor turn has produced its
+ * first durable assistant message.
+ *
+ * This is the extra test mode behind `zero-anchored-standard`: the anchor
+ * plugin seeds a fixed user message and this filter strips the whole catalog,
+ * so the first real request follows the zero-injection "we" trajectory. After
+ * that assistant response is durable, later requests see the resident
+ * catalog.
+ *
+ * WHY RESIDENT (local addition, user-measured): the promoted phase does NOT
+ * dump the whole Standard catalog at once — that dump pulls the trajectory
+ * back to standard-like behavior (measured post-promotion regression: a flood
+ * of `let me` first-lines). Instead the catalog narrows to the shells +
+ * `str_replace_editor` + the three discovery tools (`dev_tool_search`,
+ * `skill_search`, `skill_load`) plus whatever the model explicitly unlocked
+ * via `dev_tool_search`. Heavier Standard tools (web_search, subagent,
+ * workflow, …) are one `dev_tool_search` call away; unlocked names are
+ * derived from durable `tool/call` events, so resume and reload keep them.
+ *
+ * COMPACTION (local addition): a compaction rewrites the whole surface, so the
+ * first post-compaction request is a "second first request". Promotion is
+ * epoch-aware (see preset/compaction-epoch.mjs): after `compaction/end` the
+ * session falls back to a controlled phase — the shells plus `compactionTools`
+ * (a core work set, default none) — until a NEW durable assistant message
+ * exists past that boundary. The zero-tool anchor applies ONLY to the very
+ * first request: after a compaction the model is mid-task and needs to keep
+ * working, but still faces a small catalog instead of the full Standard set.
+ *
+ * Injected reminders (the AGENTS.md digest and the `<available_skills>`
+ * catalog, source kinds `agent-instructions` / `skill-catalog`) are stripped
+ * during the controlled phase — same reasoning as the anchored variant
+ * (issue #6: with the skill catalog present the anchor did not reproduce at
+ * all, 0/9). `suppressedContextSources` is configurable; an empty array
+ * disables the context filter while keeping the tool bootstrap.
+ *
+ * Robustness:
+ *  - Promotion decisions are memoized per session id for this process; the
+ *    durable event scan runs once per session per process, then O(1).
+ *  - Subagents and non-top-level agents always see the full catalog: their
+ *    first request must be able to call tools.
+ *  - A filter failure degrades to the full catalog with a one-time warning,
+ *    so a bug can never brick every request of a session.
+ */
+
+import { createEpochPromotion } from '../preset/compaction-epoch.mjs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'zero-tool-bootstrap'
+
+/**
+ * Deliberately NO inject list: the listeners only touch services at event
+ * time, and the pre-step strip below registers with `prepend: true` so it
+ * stays the OUTERMOST waterfall transform (see the anchored copy for the full
+ * registration-order reasoning).
+ */
+export const inject = []
+
+/** Same automatic injections the anchored variant strips by default. */
+const DEFAULT_SUPPRESSED_SOURCES = ['skill-catalog', 'agent-instructions']
+
+/** Shell candidates (the anchored preset's custom-bash registers `bash`; pwsh is Windows standard). */
+const SHELLS = ['bash', 'pwsh']
+
+/** Discovery tools always resident after promotion (the tool-search pattern). */
+const RESIDENT_DISCOVERY_TOOLS = ['dev_tool_search', 'skill_search', 'skill_load']
+
+function stringListOrEmpty(value, field) {
+  if (value === undefined) return []
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be a non-empty array of non-empty strings`)
+  }
+  return [...new Set(value)]
+}
+
+function sourceList(value, field, fallback) {
+  if (value === undefined) return new Set(fallback)
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be an array of non-empty strings`)
+  }
+  return new Set(value)
+}
+
+/** Register the per-session bootstrap filters. */
+export function apply(ctx, config) {
+  // Core work set exposed after a compaction, before re-promotion.
+  const compactionTools = stringListOrEmpty(config?.compactionTools, 'compactionTools')
+  const suppressedSources = sourceList(config?.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+
+  const promotion = createEpochPromotion(['assistant/message'])
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  /**
+   * Tool names the model explicitly unlocked via `dev_tool_search` for one
+   * session. Derived from durable `tool/call` events so resume/reload keeps
+   * them. The event's `arguments` is the raw JSON string the model produced;
+   * we parse it defensively and read the `toolNames` array.
+   */
+  const unlockedFor = (session) => {
+    const unlocked = new Set()
+    if (session === undefined || !Array.isArray(session.events)) return unlocked
+    for (const event of session.events) {
+      if (event.type !== 'tool/call') continue
+      if (event.data?.name !== 'dev_tool_search') continue
+      let args
+      try {
+        args = JSON.parse(event.data.arguments)
+      } catch {
+        continue
+      }
+      if (args === null || typeof args !== 'object' || Array.isArray(args)) continue
+      const names = args.toolNames
+      if (Array.isArray(names)) for (const name of names) if (typeof name === 'string' && name.length > 0) unlocked.add(name)
+    }
+    return unlocked
+  }
+
+  ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is guarded.
+    const assembled = await next()
+    try {
+      const status = promotion.status(context.agent)
+      if (status.promoted) {
+        // PROMOTED: keep the minimal resident set — the shells +
+        // str_replace_editor + the discovery tools + whatever the model
+        // explicitly unlocked via dev_tool_search — instead of dumping the
+        // whole Standard catalog at once (the post-promotion regression fix).
+        const available = new Set(assembled.tools.map((tool) => tool.name))
+        const keep = new Set([
+          ...SHELLS.filter((name) => available.has(name)),
+          'str_replace_editor', ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session),
+        ])
+        return {
+          ...assembled,
+          tools: assembled.tools.filter((tool) => keep.has(tool.name)),
+        }
+      }
+      const { boundary } = status
+      // First request (no compaction yet): zero tools, the "we" anchor.
+      if (boundary < 0) return { ...assembled, tools: [] }
+      // Post-compaction: core work set so mid-task work can continue.
+      if (compactionTools.length === 0) return { ...assembled, tools: [] }
+      const available = new Set(assembled.tools.map((tool) => tool.name))
+      const selectedShells = SHELLS.filter((toolName) => available.has(toolName))
+      const missing = compactionTools.filter((toolName) => !available.has(toolName))
+      if (selectedShells.length === 0 || missing.length > 0) {
+        warnOnce(
+          `${name}: expected at least one phase shell and every phase tool; `
+          + `shells=${JSON.stringify(selectedShells)}, missing=${JSON.stringify(missing)} — `
+          + 'bootstrap disabled, full catalog exposed',
+        )
+        return assembled
+      }
+      const keep = new Set([...selectedShells, ...compactionTools])
+      return {
+        ...assembled,
+        tools: assembled.tools.filter((tool) => keep.has(tool.name)),
+      }
+    } catch (error) {
+      // A filter bug must never brick a session: degrade to the full catalog.
+      warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
+      return assembled
+    }
+  })
+
+  // Strip injected reminders (skill catalog, AGENTS.md) during the controlled
+  // phase. Same registration discipline as the anchored variant: `prepend`
+  // keeps the strip the OUTERMOST transform of the agent/pre-step waterfall.
+  ctx.on('agent/pre-step', async ({ agent }, next) => {
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    try {
+      if (promotion.status(agent).promoted || suppressedSources.size === 0) return decision
+      if (!Array.isArray(decision.messages)) return decision
+      const kept = decision.messages.filter((message) => {
+        const kind = message?.source?.kind
+        return typeof kind !== 'string' || !suppressedSources.has(kind)
+      })
+      return kept.length === decision.messages.length ? decision : { ...decision, messages: kept }
+    } catch (error) {
+      // A filter bug must never eat context: degrade to keeping every message.
+      warnOnce(`${name}: pre-step context filter failed, keeping injected context: ${String((error && error.message) || error)}`)
+      return decision
+    }
+  }, { prepend: true })
+}


### PR DESCRIPTION
## What

Adds a new experimental preset **`whoami-standard`**: a usability-oriented variant of the zero-tool anchor idea. Whatever the user's first message is, the first model request sees only a fixed "你是谁" (who are you) prompt on an **empty tool surface**; the user's real message is deferred to the next turn, when the promoted resident catalog is already unlocked.

## Why

`zero-anchored-standard` anchors with a fixed English test message ("This round is a test..."), which is a comparison point for trajectory research. This preset keeps the same zero-tool anchor mechanics but makes the warm-up round a natural self-introduction, so the user's **first real message is always answered with tools ready** — the session is guaranteed to be promoted before real work begins, regardless of what was typed first.

## How it works

1. On the first user message, `whoami-turn` prepends the anchor into the `next-turn` inbox queue ahead of the real message.
2. dsh claims exactly ONE `next-turn` message per turn, so the first model request sees only the anchor with ZERO tools and replies with a self-introduction — that reply is the promotion signal.
3. The real message is claimed by the NEXT turn, with the promoted resident catalog (shells, `str_replace_editor`, discovery tools) already unlocked; heavier Standard tools are one `dev_tool_search` away.

The anchor text is configurable via the `whoami-turn` row's `text` option (default `你是谁`). All other mechanics reuse the current `zero-anchored-standard` structure unchanged: `zero-tool-bootstrap.mjs`, `instruction-hint`, `dev-tool-search`, `skill-search`, `custom-bash`, compaction-aware promotion, and the `../preset/` shared plugin references.

## Files

- `whoami-standard/whoami-turn.mjs` — new anchor plugin (derived from `anchor-turn.mjs`, default text `你是谁`)
- `whoami-standard/zero-tool-bootstrap.mjs` — unchanged copy of the current zero variant's bootstrap
- `whoami-standard/agent.cordis.yml` — mirrors `zero-anchored-standard/agent.cordis.yml` with the `whoami-turn` row replacing `anchor-turn`
- `whoami-standard/preset.yml` — metadata, order 7
- `test/whoami-turn.test.mjs` — 6 unit tests mirroring `anchor-turn.test.mjs` (prepend on first message, config override, no re-anchor on plugin messages, no re-anchor after a prior user message, subagents skipped)
- `README.md` / `README.zh-CN.md` — "Whoami Standard (experimental)" sections

## Verification

- `npm test`: **103/103 pass** (6 new whoami-turn tests included)
- End-to-end (DeepSeek Harness web UI, OpenCode Go gateway, DeepSeek V4 Pro): a fresh session with this preset shows exactly two turns —
  - turn 1: only the "你是谁" anchor, `request/header` with **no tools**, model replies with a self-introduction;
  - turn 2: the real user message, `request/header` with the **full resident tool catalog** (the model successfully called `mcp__balanced-search__search` in the test session).

## Trade-off

One extra model call per session — the anchor turn is always taken, even when the first message is urgent. This is the intended design (guaranteed warm-up), documented in the README.
