### PR TITLE
fix(tool-bootstrap): reject unknown config keys at apply time

### DIFF
--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -112,6 +112,9 @@ const PROMOTE_EVENTS = {
   either: ['tool/call', 'assistant/message'],
 }
 
+/** Every config key this plugin accepts — anything else is a typo. */
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools'])
+
 /**
  * Context sources stripped from the first request by default. Both are
  * automatic `agent/pre-step` injections: the available-skills reminder
@@ -178,14 +181,24 @@ function optionalPositiveInt(value, field) {
 
 /** Register the per-session bootstrap filters. */
 export function apply(ctx, config) {
-  const bootstrapTools = stringList(config.bootstrapTools, 'bootstrapTools')
-  const promoteEvents = parsePromoteOn(config.promoteOn)
-  const bootstrapMaxTokens = optionalPositiveInt(config.bootstrapMaxTokens, 'bootstrapMaxTokens')
-  const suppressedSources = sourceList(config.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+  const source = config === undefined ? {} : config
+  if (typeof source !== 'object' || source === null || Array.isArray(source)) {
+    throw new TypeError(`${name}: config must be an object`)
+  }
+  const unknown = Object.keys(source).filter((key) => !ALLOWED_KEYS.has(key))
+  if (unknown.length > 0) {
+    throw new TypeError(
+      `${name}: unknown config key(s) ${unknown.join(', ')} — allowed keys: ${[...ALLOWED_KEYS].sort().join(', ')}`,
+    )
+  }
+  const bootstrapTools = stringList(source.bootstrapTools, 'bootstrapTools')
+  const promoteEvents = parsePromoteOn(source.promoteOn)
+  const bootstrapMaxTokens = optionalPositiveInt(source.bootstrapMaxTokens, 'bootstrapMaxTokens')
+  const suppressedSources = sourceList(source.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
   // Core work set exposed after a compaction, before re-promotion. Empty
   // means "no compaction recovery catalog": the session stays on the
   // bootstrap pair until a new promotion signal.
-  const compactionTools = stringListOrEmpty(config.compactionTools, 'compactionTools')
+  const compactionTools = stringListOrEmpty(source.compactionTools, 'compactionTools')
 
   const promotion = createEpochPromotion(promoteEvents)
   ctx.on('session/event', (session, event) => promotion.observe(session, event))

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -348,3 +348,10 @@ test('invalid compactionTools values fail at apply time', () => {
   assert.throws(() => register({ ...config, compactionTools: [] }), /compactionTools/)
   assert.throws(() => register({ ...config, compactionTools: ['read', 42] }), /compactionTools/)
 })
+
+test('unknown config keys reject at apply time', () => {
+  assert.throws(() => register({ ...config, promoteOnn: 'either' }), /unknown config key/)
+  assert.throws(() => register({ bootstrapTools: ['bash'], commonTools: ['read'] }), /unknown config key/)
+  assert.throws(() => register(null), /config must be an object/)
+  assert.throws(() => register([]), /config must be an object/)
+})


### PR DESCRIPTION
### 问题现象

`tool-bootstrap` 目前对每个配置字段都做了校验,但**未知键**会被静默忽略。一个拼写错误(例如把 `promoteOn` 写成 `promoteOnn`)不会在挂载时报错,而是静默回落到默认值 —— 用户以为启用了某个触发条件,实际完全没有生效。这类"静默失效"在本地实测中被抓到过一次,排查成本远高于一个挂载期报错。

### 改动点

- `preset/tool-bootstrap.mjs`:apply 入口新增对象类型检查(`null`/数组/非对象直接拒绝)与未知键白名单校验(`ALLOWED_KEYS`,含 `bootstrapTools` / `promoteOn` / `bootstrapMaxTokens` / `suppressedContextSources` / `compactionTools`),报错信息列出允许的键;
- 所有配置读取改为从规范化后的 `source` 读取,行为不变;
- `test/tool-bootstrap.test.mjs`:新增 1 个用例(4 条断言)覆盖未知键、`null`、数组三种拒绝路径。

### 测试

- `node --test`:59/59 通过(含本 PR 新增用例;原 55 个用例全部保持原语义)。

### 备注

- 本 PR 基于 upstream/main `f57a1bd` rebase,落在 epoch/resident/compaction 方案之上,仅新增配置防呆,不触碰晋升语义。
- 分支名沿用旧名 `feat/incremental-promotion-fold`,以本 PR 内容为准。
- 相关背景 See also #6(本 PR 不解决 #6)。