### PR TITLE
fix(dev-tool-search): query schemas through the executing agent scope

### DIFF
--- a/preset/dev-tool-search.mjs
+++ b/preset/dev-tool-search.mjs
@@ -80,7 +80,7 @@ export function apply(ctx) {
       schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
       render: (_a, v) => [{ type: 'text', text: v.text }],
     },
-    async execute(args) {
+    async execute(args, exec) {
       const query = typeof args.query === 'string' ? args.query.trim() : ''
       const unlock = Array.isArray(args.toolNames) ? args.toolNames.filter((name) => typeof name === 'string' && name.length > 0) : []
 
@@ -97,7 +97,12 @@ export function apply(ctx) {
       }
 
       try {
-        const schemas = ctx.tools.schemas()
+        // The executing agent IS the viewing scope: preset tools register into
+        // the agent-scope layer of the tools registry, and schemas() with no
+        // scope only sees the global layer — every preset-provided tool would
+        // be invisible to keyword search (issue #24). Same pattern as the
+        // harness's own code mode (`registry.schemas(exec.agent)`).
+        const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
         const matches = schemas
           .filter((schema) => {

--- a/test/dev-tool-search.test.mjs
+++ b/test/dev-tool-search.test.mjs
@@ -76,3 +76,24 @@ test('a throwing catalog search degrades to a message, never throws', async () =
   const result = await spy.tools.registered.execute({ query: 'web' }, exec())
   assert.match(result.text, /catalog search unavailable/)
 })
+
+test('schemas() is queried with the executing agent as the viewing scope (issue #24)', async () => {
+  const calls = []
+  const ctx = {
+    tools: {
+      schemas(scope) {
+        calls.push(scope)
+        return [{ name: 'pwsh', description: 'Execute a PowerShell command' }]
+      },
+      register(tool) {
+        this.registered = tool
+      },
+    },
+  }
+  apply(ctx)
+  const agent = { session: { id: 's1' } }
+  const result = await ctx.tools.registered.execute({ query: 'pwsh' }, { agent })
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0], agent, 'the executing agent is the viewing scope, so agent-scoped preset tools are visible')
+  assert.match(result.text, /pwsh: Execute a PowerShell command/)
+})


### PR DESCRIPTION
### 问题现象

`dev_tool_search` 的关键词搜索在真实 DSH 上永远看不到 preset 自己的工具:`preset/dev-tool-search.mjs` 调用 `ctx.tools.schemas()` 不带 scope,而 preset 工具注册在 tools registry 的 **agent-scope 层**,无 scope 的视图只包含全局层。表现为 `query: "pwsh"` 返回 "No tools match",但按精确名解锁(`toolNames`)却正常工作 —— 后者不查目录,所以 bug 一直没暴露(issue #24 已给出根因与验证)。

### 改动点

- `execute(args)` → `execute(args, exec)`,目录查询改为 `ctx.tools.schemas(exec?.agent)` —— 与 harness 自带 code mode 的用法一致(`registry.schemas(exec.agent)`);无 agent 的执行保持旧的全局视图语义;
- 新增回归测试:断言 `schemas()` 收到执行中的 agent 作为 viewing scope,并验证关键词命中。

### 测试

`node --test`:全套 108/108 通过(dev-tool-search 8/8)。

Closes #24