### PR TITLE
fix(custom-bash): auto-detect bash.exe on Windows instead of a hardcoded path

### DIFF
--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -162,15 +162,15 @@
 # Windows-only `bash` tool (see preset/custom-bash.mjs): registers the SAME
 # tool name as the persistent shell with a Minimal-compatible description, but
 # executes through the ordinary cross-platform subprocess seam (`bash -c`)
-# instead of a PTY. `bashPath` defaults to `bash` on PATH; point it at Git
-# Bash explicitly when the WSL shim would otherwise be picked up. No OS
-# sandbox confinement on Windows (landlock is linux-only); the tool
-# description says so.
+# instead of a PTY. With no `bashPath` config the plugin auto-detects bash.exe
+# on Windows: a PATH scan preferring a Git-installed bash, any non-system
+# bash next (scoop/chocolatey/portable installs), and the WSL shim only as a
+# last resort. Pin `bashPath` to an absolute path to override. No OS sandbox
+# confinement on Windows (landlock is linux-only); the tool description says
+# so.
 - id: custom-bash
   name: ./custom-bash.mjs
   disabled: !!js process.platform !== 'win32'
-  config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 

--- a/preset/custom-bash.mjs
+++ b/preset/custom-bash.mjs
@@ -15,6 +15,10 @@
  *
  * Executable resolution (config `bashPath`):
  *  - explicit absolute path (e.g. `C:\Program Files\Git\bin\bash.exe`), or
+ *  - on Windows, an automatic PATH scan for `bash.exe` that prefers a
+ *    Git-installed bash over any other, avoids the WSL shim under the system
+ *    root when a real bash exists, and falls back to the shim as a last
+ *    resort (scoop/chocolatey/portable installs all work without config), or
  *  - `bash` resolved through `ctx.subprocess.resolveExecutable` (PATH lookup).
  *
  * Semantics mirror the official bash tool: `bash -c <command>` in a fresh
@@ -24,6 +28,8 @@
  * `str_replace_editor` (Minimal's two tools).
  */
 
+import { existsSync } from 'node:fs'
+
 /** Cordis plugin name used by loader diagnostics. */
 export const name = 'custom-bash'
 
@@ -32,6 +38,60 @@ export const inject = ['subprocess', 'tools']
 
 const DEFAULT_TIMEOUT_MS = 120000
 const DEFAULT_MAX_OUTPUT_BYTES = 64000
+
+/**
+ * Scan a Windows PATH string for existing `bash.exe` candidates, ranked by
+ * desirability: a Git-installed bash outside the system root first, any
+ * other non-system bash next (scoop shims, portable installs), and the WSL
+ * shim under the system root only as a last resort. Ties keep PATH order.
+ * @param pathEnv - the raw `PATH`-style list (`;`-separated on Windows).
+ * @param systemRoot - the Windows system root (e.g. `C:\Windows`).
+ * @param exists - existence predicate, injected for deterministic tests.
+ * @returns the best existing `bash.exe` path, or undefined when none exists.
+ */
+export function pickWindowsBash(pathEnv, systemRoot, exists) {
+  const root = String(systemRoot ?? 'C:\\Windows').toLowerCase().replace(/[\\/]+$/, '')
+  const candidates = String(pathEnv ?? '')
+    .split(';')
+    .map((entry) => entry.trim().replace(/^"|"$/g, ''))
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      const trimmed = entry.replace(/[\\/]+$/, '')
+      return trimmed.toLowerCase().endsWith('bash.exe') ? trimmed : `${trimmed}\\bash.exe`
+    })
+  const score = (candidate) => {
+    const lower = candidate.toLowerCase()
+    const isSystem = lower.startsWith(`${root}\\`) || lower === root
+    const isGit = lower.includes('git')
+    if (isGit && !isSystem) return 0
+    if (!isSystem) return 1
+    return 2
+  }
+  let best
+  for (const candidate of candidates) {
+    if (!exists(candidate)) continue
+    if (best === undefined || score(candidate) < score(best)) best = candidate
+  }
+  return best
+}
+
+/**
+ * Resolve the default executable string for the bash tool.
+ * @param configBashPath - the explicit `bashPath` config value, if any.
+ * @param platform - the host platform, for deterministic tests.
+ * @param pathEnv - the raw PATH list (Windows detection input).
+ * @param systemRoot - the Windows system root.
+ * @param exists - existence predicate.
+ * @returns an explicit path, a detected Windows candidate, or `bash`.
+ */
+export function resolveDefaultBash(configBashPath, platform, pathEnv, systemRoot, exists) {
+  if (typeof configBashPath === 'string' && configBashPath.length > 0) return configBashPath
+  if (platform === 'win32') {
+    const detected = pickWindowsBash(pathEnv, systemRoot, exists)
+    if (detected !== undefined) return detected
+  }
+  return 'bash'
+}
 
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
@@ -52,7 +112,13 @@ const commandSchema = {
 
 /** Register the model-facing `bash` tool. */
 export function apply(ctx, config) {
-  const bashPath = typeof config?.bashPath === 'string' && config.bashPath.length > 0 ? config.bashPath : 'bash'
+  const bashPath = resolveDefaultBash(
+    config?.bashPath,
+    process.platform,
+    process.env.PATH ?? '',
+    process.env.SystemRoot ?? 'C:\\Windows',
+    existsSync,
+  )
   const timeoutMs = Number.isSafeInteger(config?.timeoutMs) && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS
   const maxOutputBytes = Number.isSafeInteger(config?.maxOutputBytes) && config.maxOutputBytes > 0 ? config.maxOutputBytes : DEFAULT_MAX_OUTPUT_BYTES
 

--- a/test/custom-bash.test.mjs
+++ b/test/custom-bash.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { apply, name, inject } from '../preset/custom-bash.mjs'
+import { apply, inject, name, pickWindowsBash, resolveDefaultBash } from '../preset/custom-bash.mjs'
 
 function register(config) {
   const registered = []
@@ -125,7 +125,7 @@ test('missing output readers degrade to the exit code text', async () => {
   assert.match(result.text, /exit code: 0/)
 })
 
-test('the default bashPath falls back to `bash` on PATH', async () => {
+test('without config the executable is detected on Windows or falls back to `bash`', async () => {
   const resolved = []
   const registered = []
   const ctx = {
@@ -137,5 +137,47 @@ test('the default bashPath falls back to `bash` on PATH', async () => {
   }
   apply(ctx)
   await registered[0].execute({ command: 'x' }, exec())
-  assert.deepEqual(resolved, ['bash'])
+  assert.equal(resolved.length, 1)
+  const chosen = resolved[0]
+  if (chosen !== 'bash') {
+    assert.match(chosen.toLowerCase(), /bash\.exe$/, 'the auto-detected Windows executable is a bash.exe path (issue #28)')
+  }
+})
+
+test('pickWindowsBash prefers a Git-installed bash over other non-system bash and the WSL shim', () => {
+  const existing = new Set([
+    'C:\\Users\\me\\scoop\\shims\\bash.exe',
+    'C:\\Windows\\System32\\bash.exe',
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+  ])
+  const exists = (p) => existing.has(p)
+  const pathEnv = 'C:\\Windows\\System32;C:\\Users\\me\\scoop\\shims;C:\\Program Files\\Git\\bin'
+  assert.equal(
+    pickWindowsBash(pathEnv, 'C:\\Windows', exists),
+    'C:\\Program Files\\Git\\bin\\bash.exe',
+  )
+})
+
+test('pickWindowsBash prefers any non-system bash over the WSL shim (scoop installs)', () => {
+  const exists = (p) => p === 'C:\\Users\\me\\scoop\\shims\\bash.exe' || p === 'C:\\Windows\\System32\\bash.exe'
+  const pathEnv = 'C:\\Windows\\System32;C:\\Users\\me\\scoop\\shims'
+  assert.equal(pickWindowsBash(pathEnv, 'C:\\Windows', exists), 'C:\\Users\\me\\scoop\\shims\\bash.exe')
+})
+
+test('pickWindowsBash falls back to the WSL shim when it is the only bash', () => {
+  const exists = (p) => p === 'C:\\Windows\\System32\\bash.exe'
+  assert.equal(pickWindowsBash('C:\\Windows\\System32;C:\\elsewhere', 'C:\\Windows', exists), 'C:\\Windows\\System32\\bash.exe')
+})
+
+test('pickWindowsBash tolerates quoted entries and returns undefined when nothing exists', () => {
+  const exists = (p) => p === 'D:\\tools\\bash.exe'
+  assert.equal(pickWindowsBash('"D:\\tools";', 'C:\\Windows', exists), 'D:\\tools\\bash.exe')
+  assert.equal(pickWindowsBash('C:\\a;C:\\b', 'C:\\Windows', () => false), undefined)
+})
+
+test('resolveDefaultBash honors the explicit config, detects on win32, and falls back to bash', () => {
+  assert.equal(resolveDefaultBash('C:\\custom\\bash.exe', 'win32', '', 'C:\\Windows', () => false), 'C:\\custom\\bash.exe')
+  assert.equal(resolveDefaultBash(undefined, 'win32', 'C:\\x', 'C:\\Windows', () => true), 'C:\\x\\bash.exe')
+  assert.equal(resolveDefaultBash(undefined, 'win32', 'C:\\x', 'C:\\Windows', () => false), 'bash')
+  assert.equal(resolveDefaultBash(undefined, 'linux', 'C:\\x', 'C:\\Windows', () => true), 'bash')
 })


### PR DESCRIPTION
### 问题现象

shipped preset 把 `bashPath` 硬编码为 `C:\Program Files\Git\bin\bash.exe`,任何非默认安装(scoop / chocolatey / 便携版)都会直接坏掉(issue #28)。

### 改动点

- `preset/agent.cordis.yml`:移除硬编码的 `bashPath`,注释说明自动检测与覆盖方式;
- `preset/custom-bash.mjs`:新增 Windows 自动检测 —— 扫描 PATH 中的 `bash.exe`,按优先级选择:**Git 安装的 bash > 其他非系统目录 bash(scoop shim 等)> WSL shim(仅作最后兜底)**;同分保持 PATH 顺序。检测逻辑实现为可注入的纯函数(`pickWindowsBash` / `resolveDefaultBash`),平台无关可单测;
- 非 Windows 平台与扫描为空时,保持原有 `bash` PATH 回落;`bashPath` 仍可显式覆盖。

### 测试

`node --test`:全套 108/108 通过(custom-bash 13/13,含 5 个新纯函数用例覆盖偏好排序、引号条目、空扫描与回落)。

Closes #28