### PR TITLE
fix: scope dev_tool_search catalog to the calling agent (rc.6 registry)

### DIFF
--- a/preset/dev-tool-search.mjs
+++ b/preset/dev-tool-search.mjs
@@ -80,7 +80,7 @@ export function apply(ctx) {
       schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
       render: (_a, v) => [{ type: 'text', text: v.text }],
     },
-    async execute(args) {
+    async execute(args, exec) {
       const query = typeof args.query === 'string' ? args.query.trim() : ''
       const unlock = Array.isArray(args.toolNames) ? args.toolNames.filter((name) => typeof name === 'string' && name.length > 0) : []
 
@@ -97,7 +97,7 @@ export function apply(ctx) {
       }
 
       try {
-        const schemas = ctx.tools.schemas()
+        const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
         const matches = schemas
           .filter((schema) => {

--- a/test/dev-tool-search.test.mjs
+++ b/test/dev-tool-search.test.mjs
@@ -5,9 +5,11 @@ import { apply, name } from '../preset/dev-tool-search.mjs'
 
 function register(schemas = []) {
   const registered = []
+  const calls = []
   const ctx = {
     tools: {
-      schemas() {
+      schemas(scope) {
+        calls.push(scope)
         return schemas
       },
       register(tool) {
@@ -16,7 +18,7 @@ function register(schemas = []) {
     },
   }
   apply(ctx)
-  return { registered, ctx }
+  return { registered, ctx, calls }
 }
 
 const exec = (args) => ({ agent: { session: { id: 's', header: {} } }, signal: undefined, ...args })
@@ -75,4 +77,13 @@ test('a throwing catalog search degrades to a message, never throws', async () =
   apply(spy)
   const result = await spy.tools.registered.execute({ query: 'web' }, exec())
   assert.match(result.text, /catalog search unavailable/)
+})
+
+test('search scopes the catalog to the calling agent (rc.6 scope-layered registry)', async () => {
+  const agent = { session: { id: 's', header: {} } }
+  const { registered, calls } = register([{ name: 'subagent', description: 'delegate work' }])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({ query: 'subagent' }, exec({ agent }))
+  assert.match(result.text, /subagent/)
+  assert.equal(calls.at(-1), agent)
 })


### PR DESCRIPTION
**修复**：`dev_tool_search` 在 DeepSeek Harness `0.1.0-rc.6` 上搜索不到任何 preset 工具，解锁链路完全失效。

### 现象（rc.6 真实会话日志）

- 晋升后的 resident 目录按设计只有 `bash / str_replace_editor / dev_tool_search / skill_search / skill_load`；
- 模型 4 次调用 `dev_tool_search` 查询 `goal`、`subagent`，结果全部为 `No tools match "..."`（连精确注册的工具名都搜不到）；
- 模型随后回复“目标工具与子代理工具在当前目录中不可用”，会话全程只有两份 request/header——解锁从未生效。

### 根因

rc.6 的工具注册表改为 scope 分层视图（`packages/core/tools`）：

- `schemas(scope?)` 省略参数 = 只返回 **global 层**；
- preset 注册的工具全部落在**会话 scope 层**（源码注释原话 “presets moved them onto the agent plane”）。

`dev-tool-search.mjs` 无参调用 `ctx.tools.schemas()`，搜索的始终是空的 global 视图。仓库里 `skill-search.mjs` 对 skills 的写法（`ctx.skills.list({ scope: exec?.agent })`）就是正确模式。

### 修改

```diff
-    async execute(args) {
+    async execute(args, exec) {
...
-        const schemas = ctx.tools.schemas()
+        const schemas = ctx.tools.schemas(exec?.agent)
```

并新增回归测试：断言 `schemas` 以执行 agent 为 scope 调用（旧代码下该测试失败）。

### 验证

- 仓库测试 104/104 通过（含新增回归测试）；
- rc.6 部署上三个 preset（anchored/zero/whoami 共用本文件）`standingKeyFor` 挂载校验通过；
- 端到端（真实会话中解锁后目录变化）建议在 rc.6 环境复核。
