### PR TITLE
修复 issue #24:推断 Git Bash 路径,移除硬编码

### DIFF
--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -162,15 +162,18 @@
 # Windows-only `bash` tool (see preset/custom-bash.mjs): registers the SAME
 # tool name as the persistent shell with a Minimal-compatible description, but
 # executes through the ordinary cross-platform subprocess seam (`bash -c`)
-# instead of a PTY. `bashPath` defaults to `bash` on PATH; point it at Git
-# Bash explicitly when the WSL shim would otherwise be picked up. No OS
+# instead of a PTY. The shell is resolved WITHOUT a hardcoded install path
+# (issue #24): `bashPath` unset probes the `git` executable's install root,
+# then the well-known Git-for-Windows roots (Program Files(/x86), per-user
+# LOCALAPPDATA, scoop's `current` junction), then plain `bash` on PATH — set
+# `bashPath` explicitly only to pin a shell that probing cannot find. No OS
 # sandbox confinement on Windows (landlock is linux-only); the tool
-# description says so.
+# description says so. When no bash exists at all the tool errors with
+# guidance instead of switching shells — pwsh stays its own tool in the
+# promoted catalog.
 - id: custom-bash
   name: ./custom-bash.mjs
   disabled: !!js process.platform !== 'win32'
-  config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 

--- a/preset/custom-bash.mjs
+++ b/preset/custom-bash.mjs
@@ -13,9 +13,27 @@
  * the ordinary (cross-platform) subprocess seam keeps the schema anchor
  * without the PTY dependency.
  *
- * Executable resolution (config `bashPath`):
- *  - explicit absolute path (e.g. `C:\Program Files\Git\bin\bash.exe`), or
- *  - `bash` resolved through `ctx.subprocess.resolveExecutable` (PATH lookup).
+ * Executable resolution (config `bashPath`, issue #24 — no hardcoded install
+ * path): an explicit non-empty `bashPath` wins unconditionally. Unset, the
+ * Git Bash executable is INFERRED, in probe order:
+ *  1. the `git` executable on PATH — its install root carries `bin\bash.exe`
+ *     one level up from `cmd\`, beside `bin\`, or two levels up from
+ *     `mingw64\bin\` (the standard installer, choco, and winget all resolve
+ *     here; a scoop SHIM does not — its directory is the shims root, not the
+ *     app — which is what step 2 covers);
+ *  2. the well-known Git-for-Windows roots derived from environment variables
+ *     (`ProgramFiles`, `ProgramFiles(x86)`, per-user `LOCALAPPDATA\Programs
+ *     \Git`, scoop's `~\scoop\apps\git\current` junction);
+ *  3. plain `bash` through `ctx.subprocess.resolveExecutable` (PATH lookup —
+ *     last resort, since on Windows that may pick the WSL shim; WSL bash is
+ *     still true bash, only the filesystem paths shift to /mnt/…).
+ *
+ * If NOTHING resolves, the tool fails with an actionable error naming the
+ * remedies — it does NOT silently execute under a different shell: the
+ * schema above promises `bash -c` semantics, and pwsh/cmd are different
+ * command languages. PowerShell stays available as its OWN tool (`pwsh`,
+ * present in the promoted catalog on Windows, unlockable via
+ * dev_tool_search).
  *
  * Semantics mirror the official bash tool: `bash -c <command>` in a fresh
  * process, bounded output, non-zero exit reported not thrown. No sandbox
@@ -23,6 +41,9 @@
  * description says so. The bootstrap catalog pairs this with
  * `str_replace_editor` (Minimal's two tools).
  */
+
+import { access } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 
 /** Cordis plugin name used by loader diagnostics. */
 export const name = 'custom-bash'
@@ -32,6 +53,34 @@ export const inject = ['subprocess', 'tools']
 
 const DEFAULT_TIMEOUT_MS = 120000
 const DEFAULT_MAX_OUTPUT_BYTES = 64000
+
+/**
+ * Git Bash candidate paths, in probe order (see the header): the `git`
+ * executable's install root first, then the well-known env-derived roots.
+ * Exported for tests; pure — existence probing happens at the call site.
+ */
+export function bashCandidates(env, gitExe) {
+  const candidates = []
+  // git at <root>\cmd\git.exe (installer/scoop) or <root>\bin\git.exe →
+  // <root>\bin\bash.exe; <root>\mingw64\bin\git.exe (portable) → two up.
+  // A bare relative name means `git` did not actually resolve to a path.
+  if (typeof gitExe === 'string' && /[/\\]/.test(gitExe)) {
+    const dir = dirname(gitExe)
+    const root = dirname(dir)
+    candidates.push(
+      join(root, 'bin', 'bash.exe'),
+      join(dir, 'bash.exe'),
+      join(dirname(root), 'bin', 'bash.exe'),
+    )
+  }
+  if (env.ProgramFiles) candidates.push(join(env.ProgramFiles, 'Git', 'bin', 'bash.exe'))
+  if (env['ProgramFiles(x86)']) candidates.push(join(env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'))
+  if (env.LOCALAPPDATA) candidates.push(join(env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe'))
+  if (env.USERPROFILE) candidates.push(join(env.USERPROFILE, 'scoop', 'apps', 'git', 'current', 'bin', 'bash.exe'))
+  // Layouts overlap (a `bin` git.exe derives the same bash twice) — probe
+  // order survives the dedupe, insertion order is preserved.
+  return [...new Set(candidates)]
+}
 
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
@@ -52,9 +101,53 @@ const commandSchema = {
 
 /** Register the model-facing `bash` tool. */
 export function apply(ctx, config) {
-  const bashPath = typeof config?.bashPath === 'string' && config.bashPath.length > 0 ? config.bashPath : 'bash'
+  const explicitBashPath = typeof config?.bashPath === 'string' && config.bashPath.length > 0 ? config.bashPath : undefined
   const timeoutMs = Number.isSafeInteger(config?.timeoutMs) && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS
   const maxOutputBytes = Number.isSafeInteger(config?.maxOutputBytes) && config.maxOutputBytes > 0 ? config.maxOutputBytes : DEFAULT_MAX_OUTPUT_BYTES
+
+  // The inferred executable is memoized per plugin instance: candidate probing
+  // walks the filesystem, and the answer cannot change within a mount. A
+  // failed inference is NOT memoized — the plain `bash` fallback resolves
+  // fresh on every execute until some probe succeeds.
+  let inferredShell
+  const exists = (path) => access(path).then(() => true, () => false)
+  const resolveShell = async (signal) => {
+    if (explicitBashPath !== undefined) {
+      // A misconfigured explicit path must fail as itself, not as a
+      // discovery miss — the raw resolution error says which path failed.
+      return ctx.subprocess.resolveExecutable(explicitBashPath, undefined, signal)
+    }
+    if (inferredShell !== undefined) {
+      return ctx.subprocess.resolveExecutable(inferredShell, undefined, signal)
+    }
+    let gitExe
+    try {
+      gitExe = await ctx.subprocess.resolveExecutable('git', undefined, signal)
+    } catch {
+      // git unresolvable → the env-derived candidates below still apply
+    }
+    for (const candidate of bashCandidates(process.env, gitExe)) {
+      if (!(await exists(candidate))) continue
+      try {
+        inferredShell = await ctx.subprocess.resolveExecutable(candidate, undefined, signal)
+        return inferredShell
+      } catch {
+        // Exists but unresolvable (EPERM, a broken scoop junction): keep
+        // probing — one bad root must not block the rest of the chain, and
+        // nothing is memoized so later executes can still find a good one.
+        continue
+      }
+    }
+    try {
+      return await ctx.subprocess.resolveExecutable('bash', undefined, signal)
+    } catch (error) {
+      // Total discovery failure (no Git Bash root, no env root, no bash on
+      // PATH): name the remedies instead of leaking a raw ENOENT. Never
+      // fall back to pwsh/cmd here — the schema promises `bash -c`
+      // semantics; a different shell would silently break every command.
+      throw new Error(`bash executable not found — install Git for Windows, expose a bash on PATH, or set the custom-bash \`bashPath\` config (${String((error && error.message) || error)})`)
+    }
+  }
 
   ctx.tools.register({
     name: 'bash',
@@ -81,7 +174,7 @@ export function apply(ctx, config) {
       render: (_args, value) => [{ type: 'text', text: value.text }],
     },
     async execute(args, exec) {
-      const shell = await ctx.subprocess.resolveExecutable(bashPath, undefined, exec?.signal)
+      const shell = await resolveShell(exec?.signal)
       const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
         : exec?.agent?.session?.header?.cwd

--- a/test/custom-bash.test.mjs
+++ b/test/custom-bash.test.mjs
@@ -1,14 +1,19 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { apply, name, inject } from '../preset/custom-bash.mjs'
+import { apply, bashCandidates, name, inject } from '../preset/custom-bash.mjs'
 
 function register(config) {
   const registered = []
   const spawnCalls = []
+  const resolved = []
   const ctx = {
     subprocess: {
       async resolveExecutable(path) {
+        resolved.push(path)
         return path
       },
       spawn(options) {
@@ -29,7 +34,20 @@ function register(config) {
     },
   }
   apply(ctx, config)
-  return { tool: registered[0], spawnCalls, ctx }
+  return { tool: registered[0], spawnCalls, resolved, ctx }
+}
+
+/** Redirect every env var bashCandidates() reads at a nonexistent root. */
+function isolateBashEnv(root) {
+  const keys = ['ProgramFiles', 'ProgramFiles(x86)', 'LOCALAPPDATA', 'USERPROFILE']
+  const saved = keys.map((key) => [key, process.env[key]])
+  for (const key of keys) process.env[key] = join(root, 'nowhere')
+  return () => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  }
 }
 
 const exec = (overrides = {}) => ({
@@ -57,6 +75,12 @@ test('execute spawns `bash -c <command>` and returns the combined output', async
   assert.equal(result.text, 'hello from bash')
   assert.equal(spawnCalls.length, 1)
   assert.deepEqual(spawnCalls[0].argv, ['C:/Program Files/Git/bin/bash.exe', '-c', 'echo hi'])
+})
+
+test('an explicit bashPath bypasses inference entirely (issue #24)', async () => {
+  const { tool, resolved } = register({ bashPath: 'D:/shims/git-bash.exe' })
+  await tool.execute({ command: 'echo hi' }, exec())
+  assert.deepEqual(resolved, ['D:/shims/git-bash.exe'])
 })
 
 test('execute passes the session cwd by default and honors an explicit workdir', async () => {
@@ -125,17 +149,180 @@ test('missing output readers degrade to the exit code text', async () => {
   assert.match(result.text, /exit code: 0/)
 })
 
-test('the default bashPath falls back to `bash` on PATH', async () => {
-  const resolved = []
+test('the default falls back to `bash` on PATH after probing git (issue #24)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'custom-bash-'))
+  const restoreEnv = isolateBashEnv(dir)
+  try {
+    const registered = []
+    const resolved = []
+    const ctx = {
+      subprocess: {
+        // Identity resolution: `git` stays a bare name, so the install-root
+        // derivation is skipped and no well-known root exists under `dir`.
+        async resolveExecutable(path) { resolved.push(path); return path },
+        spawn() { return { done: Promise.resolve({ exitCode: 0 }), collected: { stdout: { readFrom() { return { text: 'ok' } } }, stderr: { readFrom() { return { text: '' } } } } } },
+      },
+      tools: { register(t) { registered.push(t) } },
+    }
+    apply(ctx)
+    await registered[0].execute({ command: 'x' }, exec())
+    assert.deepEqual(resolved, ['git', 'bash'])
+  } finally {
+    restoreEnv()
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('inference spawns the bash.exe beside a resolved git executable (issue #24)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'custom-bash-'))
+  const restoreEnv = isolateBashEnv(dir)
+  try {
+    const gitRoot = join(dir, 'Git')
+    const gitExe = join(gitRoot, 'cmd', 'git.exe')
+    const bashExe = join(gitRoot, 'bin', 'bash.exe')
+    await mkdir(join(gitRoot, 'cmd'), { recursive: true })
+    await mkdir(join(gitRoot, 'bin'), { recursive: true })
+    await writeFile(gitExe, '')
+    await writeFile(bashExe, '')
+    const registered = []
+    const resolved = []
+    const spawnCalls = []
+    const ctx = {
+      subprocess: {
+        async resolveExecutable(path) {
+          resolved.push(path)
+          return path === 'git' ? gitExe : path
+        },
+        spawn(options) {
+          spawnCalls.push(options)
+          return { done: Promise.resolve({ exitCode: 0 }), collected: { stdout: { readFrom() { return { text: 'ok' } } }, stderr: { readFrom() { return { text: '' } } } } }
+        },
+      },
+      tools: { register(t) { registered.push(t) } },
+    }
+    apply(ctx)
+    await registered[0].execute({ command: 'x' }, exec())
+    assert.equal(spawnCalls[0].argv[0], bashExe)
+    // The inference is memoized: a second execute resolves the found shell
+    // directly instead of re-probing `git`.
+    await registered[0].execute({ command: 'x' }, exec())
+    assert.deepEqual(resolved, ['git', bashExe, bashExe])
+  } finally {
+    restoreEnv()
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('a totally unresolvable shell fails with an actionable error, not a raw ENOENT (issue #24)', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'custom-bash-'))
+  const restoreEnv = isolateBashEnv(dir)
+  try {
+    const registered = []
+    const ctx = {
+      subprocess: {
+        // Every lookup throws: `git`, every candidate, and the PATH fallback.
+        async resolveExecutable() { throw new Error('ENOENT: no bash in PATH') },
+        spawn() { throw new Error('spawn must not be reached') },
+      },
+      tools: { register(t) { registered.push(t) } },
+    }
+    apply(ctx)
+    await assert.rejects(
+      () => registered[0].execute({ command: 'x' }, exec()),
+      /bash executable not found[\s\S]*`bashPath`[\s\S]*ENOENT/,
+    )
+  } finally {
+    restoreEnv()
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('an existing-but-unresolvable candidate does not block the fallback chain', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'custom-bash-'))
+  const restoreEnv = isolateBashEnv(dir)
+  try {
+    const gitRoot = join(dir, 'Git')
+    const gitExe = join(gitRoot, 'cmd', 'git.exe')
+    const bashExe = join(gitRoot, 'bin', 'bash.exe')
+    await mkdir(join(gitRoot, 'cmd'), { recursive: true })
+    await mkdir(join(gitRoot, 'bin'), { recursive: true })
+    await writeFile(gitExe, '')
+    await writeFile(bashExe, '')
+    const registered = []
+    const resolved = []
+    const spawnCalls = []
+    const ctx = {
+      subprocess: {
+        async resolveExecutable(path) {
+          resolved.push(path)
+          if (path === 'git') return gitExe
+          if (path === bashExe) throw new Error('EPERM: broken scoop junction')
+          return path
+        },
+        spawn(options) {
+          spawnCalls.push(options)
+          return { done: Promise.resolve({ exitCode: 0 }), collected: { stdout: { readFrom() { return { text: 'ok' } } }, stderr: { readFrom() { return { text: '' } } } } }
+        },
+      },
+      tools: { register(t) { registered.push(t) } },
+    }
+    apply(ctx)
+    await registered[0].execute({ command: 'x' }, exec())
+    // The broken root is probed, skipped, and the PATH fallback serves the call.
+    assert.deepEqual(resolved, ['git', bashExe, 'bash'])
+    assert.equal(spawnCalls[0].argv[0], 'bash')
+  } finally {
+    restoreEnv()
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('a misconfigured explicit bashPath surfaces the raw resolution error, not the discovery hint', async () => {
   const registered = []
   const ctx = {
     subprocess: {
-      async resolveExecutable(path) { resolved.push(path); return path },
-      spawn() { return { done: Promise.resolve({ exitCode: 0 }), collected: { stdout: { readFrom() { return { text: 'ok' } } }, stderr: { readFrom() { return { text: '' } } } } } },
+      async resolveExecutable(path) { throw new Error(`ENOENT: no ${path} on this machine`) },
+      spawn() { throw new Error('spawn must not be reached') },
     },
     tools: { register(t) { registered.push(t) } },
   }
-  apply(ctx)
-  await registered[0].execute({ command: 'x' }, exec())
-  assert.deepEqual(resolved, ['bash'])
+  apply(ctx, { bashPath: 'X:/no/such/bash.exe' })
+  await assert.rejects(
+    () => registered[0].execute({ command: 'x' }, exec()),
+    (error) => error.message.includes('X:/no/such/bash.exe') && !error.message.includes('bash executable not found'),
+  )
+})
+
+test('bashCandidates probes the git install root first, then env-derived roots', () => {
+  // Expected values are built with join() so the assertions hold on both
+  // path-module flavors (win32 normalizes to backslashes).
+  const env = {
+    ProgramFiles: 'C:/Program Files',
+    'ProgramFiles(x86)': 'C:/Program Files (x86)',
+    LOCALAPPDATA: 'C:/Users/u/AppData/Local',
+    USERPROFILE: 'C:/Users/u',
+  }
+  const candidates = bashCandidates(env, 'C:/Program Files/Git/cmd/git.exe')
+  assert.deepEqual(candidates, [
+    join('C:/Program Files/Git', 'bin', 'bash.exe'),
+    join('C:/Program Files/Git/cmd', 'bash.exe'),
+    join('C:/Program Files', 'bin', 'bash.exe'),
+    join('C:/Program Files (x86)', 'Git', 'bin', 'bash.exe'),
+    join('C:/Users/u/AppData/Local', 'Programs', 'Git', 'bin', 'bash.exe'),
+    join('C:/Users/u', 'scoop', 'apps', 'git', 'current', 'bin', 'bash.exe'),
+  ])
+})
+
+test('bashCandidates derives the portable mingw64 layout and skips an unresolved git name', () => {
+  const env = { USERPROFILE: '/home/u' }
+  const portable = bashCandidates(env, '/opt/PortableGit/mingw64/bin/git.exe')
+  assert.deepEqual(portable, [
+    join('/opt/PortableGit/mingw64/bin', 'bash.exe'),
+    join('/opt/PortableGit', 'bin', 'bash.exe'),
+    join('/home/u', 'scoop', 'apps', 'git', 'current', 'bin', 'bash.exe'),
+  ])
+  // A bare `git` (identity resolution, no directory) yields env roots only.
+  const envOnly = [join('/home/u', 'scoop', 'apps', 'git', 'current', 'bin', 'bash.exe')]
+  assert.deepEqual(bashCandidates(env, 'git'), envOnly)
+  assert.deepEqual(bashCandidates(env, undefined), envOnly)
 })

--- a/whoami-standard/agent.cordis.yml
+++ b/whoami-standard/agent.cordis.yml
@@ -111,14 +111,16 @@
 # Windows-only `bash` tool (see preset/custom-bash.mjs): the official bash
 # needs a PTY, and DSH's PTY backend is linux/darwin-only. This row presents
 # the SAME tool name (`bash`) with a Minimal-compatible description but spawns
-# Git Bash through the ordinary cross-platform subprocess seam. `bashPath`
-# defaults to `bash` on PATH; point it at Git Bash explicitly when the WSL
-# shim would otherwise be picked up.
+# Git Bash through the ordinary cross-platform subprocess seam. No hardcoded
+# install path (issue #24): unset `bashPath` probes the `git` executable's
+# install root, then the well-known Git-for-Windows roots (Program
+# Files(/x86), per-user LOCALAPPDATA, scoop), then plain `bash` on PATH —
+# set `bashPath` explicitly only to pin a shell that probing cannot find. When no bash
+# exists at all the tool errors with guidance instead of switching shells
+# (pwsh stays its own tool).
 - id: custom-bash
   name: ../preset/custom-bash.mjs
   disabled: !!js process.platform !== 'win32'
-  config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -105,14 +105,16 @@
 # Windows-only `bash` tool (see preset/custom-bash.mjs): the official bash
 # needs a PTY, and DSH's PTY backend is linux/darwin-only. This row presents
 # the SAME tool name (`bash`) with a Minimal-compatible description but spawns
-# Git Bash through the ordinary cross-platform subprocess seam. `bashPath`
-# defaults to `bash` on PATH; point it at Git Bash explicitly when the WSL
-# shim would otherwise be picked up.
+# Git Bash through the ordinary cross-platform subprocess seam. No hardcoded
+# install path (issue #24): unset `bashPath` probes the `git` executable's
+# install root, then the well-known Git-for-Windows roots (Program
+# Files(/x86), per-user LOCALAPPDATA, scoop), then plain `bash` on PATH —
+# set `bashPath` explicitly only to pin a shell that probing cannot find. When no bash
+# exists at all the tool errors with guidance instead of switching shells
+# (pwsh stays its own tool).
 - id: custom-bash
   name: ../preset/custom-bash.mjs
   disabled: !!js process.platform !== 'win32'
-  config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
# 修复 issue #24:推断 Git Bash 路径,移除硬编码

Fixes #24

> 说明:本 PR 原先同时包含 issue #28 的修复,该部分已由 #29 合入,故移除并 rebase 到最新 main,现在只针对 issue #24。

## 根因

三份组合文件(`preset/`、`zero-anchored-standard/`、`whoami-standard/` 的 `agent.cordis.yml`)将 `bashPath` 固定为 `C:\Program Files\Git\bin\bash.exe`,不兼容 scoop、用户级安装、便携版等其他安装布局。

## 修复

移除三处硬编码,`custom-bash.mjs` 改为执行时推断,探测顺序:

1. **PATH 上 `git` 可执行文件所在的安装根目录** —— 覆盖 `cmd\`、`bin\`、`mingw64\bin\` 三种布局(标准安装器 / choco / winget 均命中);
2. **环境变量推导的知名路径** —— `ProgramFiles`、`ProgramFiles(x86)`、用户级 `LOCALAPPDATA\Programs\Git`、scoop 的 `~\scoop\apps\git\current`;
3. **PATH 上的裸 `bash`** —— 最后兜底(若命中 WSL bash 也仍是真 bash,仅路径变为 `/mnt/...`)。

要点:

- 显式 `bashPath` 配置仍无条件优先;
- 推断结果按插件实例记忆化,失败不缓存(装好 Git Bash 后下一次执行即自动拾取);
- "存在但解析失败"的候选(EPERM、损坏的 scoop junction)不会阻断后续候选;
- 全部探测失败时报出可操作的错误(安装 Git for Windows / 在 PATH 上提供 bash / 设置 `bashPath`),而非裸 ENOENT;
- **不做静默 pwsh/cmd 替换**:工具 schema 承诺 `bash -c` 语义,换 shell 会让每条命令以不明原因失败;PowerShell 保持为晋升目录中的独立 `pwsh` 工具。

## 与 #30(PATH 扫描方案)的差异

#30 沿 PATH 逐目录探测 `bash.exe`,按"Git 相关非系统路径 → 非系统路径 → WSL shim"排序。它有一个盲区:**Git for Windows 标准安装只把 `Git\cmd` 加入 PATH,`Git\bin`(bash.exe 所在)默认不在 PATH 上**,所以标准安装 + WSL 并存的机器上,PATH 扫描找不到真正的 Git Bash,会落到 WSL shim。本 PR 的第 1 级探测从 `git` 可执行文件反推安装根,不依赖 `Git\bin` 是否在 PATH;两方案也可以互补(PATH 扫描可作为额外的一级)。

## 测试

- `npm test`:112 个测试全部通过(rebase 自最新 main,含 #29 新增测试);
- 新增 10 个测试:候选顺序纯函数、临时目录端到端推断、记忆化、显式覆盖、坏候选不阻断链条、总失败可操作报错等;断言全部用 `path.join` 构造,Windows 与 Linux CI 均确定性成立;
- 真实 Windows 机器冒烟验证:`git` 解析到 `mingw64\bin\git.exe` 时,推断正确命中两级向上的 `C:\Program Files\Git\bin\bash.exe`。
