### PR TITLE
feat: fork-safe resident catalog controls + Windows Git Bash kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "scripts": {
     "test": "node --test",
-    "check": "node --check preset/tool-bootstrap.mjs && node --test"
+    "check": "node --check preset/tool-bootstrap.mjs && node --check zero-anchored-standard/context-defer.mjs && node --test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "scripts": {
     "test": "node --test",
-    "check": "node --check preset/tool-bootstrap.mjs && node --check zero-anchored-standard/context-defer.mjs && node --test"
+    "check": "node --check preset/tool-bootstrap.mjs && node --check zero-anchored-standard/context-defer.mjs && node --check preset/gitbash-executor.mjs && node --check preset/gitbash-tool.mjs && node --check preset/msys-path-bridge.mjs && node --test"
   }
 }

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -128,8 +128,8 @@
 # while the tool registers into this agent's scoped catalog.
 #
 # DISABLED ON WINDOWS: DSH's PTY backend is linux/darwin-only, so the
-# persistent shell cannot serve win32. The `custom-bash` row below registers
-# the same `bash` tool name there instead (platform-exclusive).
+# persistent shell cannot serve win32. The `gitbash-shell` group below
+# registers the same `bash` tool name there instead (platform-exclusive).
 - id: persistent-shell
   name: cordis:group
   group: true
@@ -159,18 +159,37 @@
           * Please avoid commands that may produce a very large amount of output.
           * Please run long lived commands in the background, e.g. 'sleep 10 &' or start a server in the background.
 
-# Windows-only `bash` tool (see preset/custom-bash.mjs): registers the SAME
-# tool name as the persistent shell with a Minimal-compatible description, but
-# executes through the ordinary cross-platform subprocess seam (`bash -c`)
-# instead of a PTY. `bashPath` defaults to `bash` on PATH; point it at Git
-# Bash explicitly when the WSL shim would otherwise be picked up. No OS
-# sandbox confinement on Windows (landlock is linux-only); the tool
-# description says so.
-- id: custom-bash
-  name: ./custom-bash.mjs
+# Windows Git Bash shell group: a sandbox-gated executor (Git-for-Windows
+# auto-detection + full-access gate + spill-bounded output) and a
+# Minimal-surface `bash` tool (command + workdir only).
+- id: gitbash-shell
+  name: cordis:group
+  group: true
   disabled: !!js process.platform !== 'win32'
+  isolate:
+    shell: true
   config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
+    - id: gitbash-executor
+      name: ./gitbash-executor.mjs
+      config:
+        timeoutMs: 120000
+        maxTimeoutMs: 600000
+        maxOutputBytes: 64000
+        maxSpillBytes: 67108864
+        graceMs: 3000
+
+    - id: tool-gitbash
+      name: ./gitbash-tool.mjs
+      config:
+        timeoutMs: 120000
+        maxOutputBytes: 64000
+
+# Windows-only MSYS path bridge for the host-plane file tools: model passes
+# `/c/...` or `/d/...`, execution receives `C:\...` / `D:\...`.
+- id: msys-path-bridge
+  name: ./msys-path-bridge.mjs
+  config:
+    tools: [read, write, edit, grep, glob, read_image]
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 
@@ -205,6 +224,12 @@
       name: '@deepseek-ai/dsh-tool-str-replace-editor'
       config:
         maxOutputChars: 16000
+
+    # Same MSYS path bridge for the bootstrap editor's `path` argument.
+    - id: msys-editor-bridge
+      name: ./msys-path-bridge.mjs
+      config:
+        tools: [str_replace_editor]
 
 # ── background jobs ────────────────────────────────────────────────────────
 

--- a/preset/compaction-epoch.mjs
+++ b/preset/compaction-epoch.mjs
@@ -1,9 +1,9 @@
 /**
- * Epoch-aware promotion tracker shared by the bootstrap and baseline-gate
- * plugins of the anchored presets.
+ * Epoch-aware promotion tracker shared by the bootstrap plugins of the
+ * anchored presets.
  *
  * A compaction rewrites the model-visible surface: the pre-compaction
- * conversation collapses into one synthetic summary message, and the
+ * conversation collapses into one synthetic summary message and the
  * workspace-instruction baseline is re-injected from scratch. The first
  * post-compaction request is therefore a "second first request" — the same
  * first-token conditions the anchored presets exist to control. Promotion is
@@ -12,22 +12,38 @@
  * last `compaction/end` boundary counts as promoted. Before any compaction
  * the boundary is -1, which preserves the original one-shot semantics.
  *
- * State is memoized per session id and maintained incrementally through
- * `observe()`; a cold session scans its durable log once (so resume and
- * reload reconstruct the same phase), then O(1).
+ * Fork isolation (local addition): a forked session replays its parent's
+ * durable events below `header.seedLength`. Those inherited events must not
+ * promote (or re-promote) the child, so the scan and the incremental feed both
+ * ignore every event whose seq is below that boundary. State is memoized per
+ * session OBJECT (WeakMap), never by session id, so tests and forks cannot
+ * collide through string keys.
  */
+
+/**
+ * Events this session produced itself. `header.seedLength` is the durable
+ * fork-lineage boundary: forked sessions replay parent history below that seq,
+ * so only events at or after it count toward THIS session's anchor.
+ */
+function ownedEvents(session) {
+  const events = session?.events
+  if (events === undefined) return []
+  const seedLength = Number(session.header?.seedLength ?? 0)
+  if (seedLength <= 0) return events
+  return events.filter(event => event.seq === undefined || event.seq >= seedLength)
+}
 
 /** Build one epoch-aware promotion tracker. */
 export function createEpochPromotion(promoteEvents) {
   const promote = new Set(promoteEvents)
-  /** sessionId -> { boundary, promoted } */
-  const state = new Map()
+  /** session object -> { boundary, promoted } */
+  const state = new WeakMap()
 
-  /** Scan a session's durable log from scratch (cold start / resume). */
+  /** Scan a session's OWN durable log from scratch (cold start / resume / fork). */
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of ownedEvents(session)) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq
@@ -37,7 +53,7 @@ export function createEpochPromotion(promoteEvents) {
       if (promote.has(event.type) && seq > boundary) promoted = true
     }
     const entry = { boundary, promoted }
-    state.set(session.id, entry)
+    state.set(session, entry)
     return entry
   }
 
@@ -45,7 +61,7 @@ export function createEpochPromotion(promoteEvents) {
     /**
      * Current phase of the agent's session.
      * @param agent - the assembly/pre-step agent, or undefined outside an agent.
-     * @returns { boundary, promoted } — `boundary` is the last compaction/end
+     * @returns { boundary, promoted } — `boundary` is the last OWN compaction/end
      *   seq (-1 before any compaction); `promoted` is true when a durable
      *   promotion signal exists after that boundary.
      */
@@ -55,19 +71,22 @@ export function createEpochPromotion(promoteEvents) {
       if (session === undefined) return { boundary: -1, promoted: true }
       // Subagents keep the full catalog from their very first request.
       if ((session.header?.delegationDepth ?? 0) > 0) return { boundary: -1, promoted: true }
-      return state.get(session.id) ?? scan(session)
+      return state.get(session) ?? scan(session)
     },
+
     /** Incremental feed: call on every `session/event`. */
     observe(session, event) {
-      const entry = state.get(session.id)
-      if (entry === undefined) return
+      const entry = state.get(session)
+      if (entry === undefined) return // status() cold-scans the complete log
+      const seedLength = Number(session.header?.seedLength ?? 0)
+      if (seedLength > 0 && event.seq !== undefined && event.seq < seedLength) return
       const seq = event.seq ?? 0
       if (event.type === 'compaction/end') {
-        state.set(session.id, { boundary: seq, promoted: false })
+        state.set(session, { boundary: seq, promoted: false })
         return
       }
       if (promote.has(event.type) && seq > entry.boundary && !entry.promoted) {
-        state.set(session.id, { ...entry, promoted: true })
+        state.set(session, { ...entry, promoted: true })
       }
     },
   }

--- a/preset/gitbash-executor.mjs
+++ b/preset/gitbash-executor.mjs
@@ -1,0 +1,334 @@
+/**
+ * gitbash-executor: Git-for-Windows bash provider for the `minimal-gitbash`
+ * agent preset.
+ *
+ * Why this file exists:
+ *  - the shipped `minimal` preset's persistent PTY shell cannot start on
+ *    Windows (`@deepseek-ai/dsh-subprocess-local` refuses win32 terminal
+ *    inspection), and
+ *  - `@deepseek-ai/dsh-bash-local` hardcodes `bash` from PATH, which a
+ *    Windows machine does not provide.
+ *
+ * This plugin replaces `ctx.shell` inside an entry-local realm (see the
+ * preset's `gitbash-shell` group) and runs every command as
+ * `"<git bash>" -c <command>` through the host subprocess service — a fresh
+ * shell per call, with the same `bash` tool name and `str_replace_editor`
+ * surface as the original preset. Only Node built-in modules are imported:
+ * preset-local files resolve against the preset directory, so DSH package
+ * imports (node_modules) would fail, while `node:fs` is always available.
+ *
+ * Sandbox note: the MSYS runtime cannot initialize inside the Windows
+ * restricted-token sandbox (it cannot create its signal pipes), so commands
+ * are gated on the danger-full-access policy. The bash tool's single-call
+ * `sandbox_permissions: "danger-full-access"` escalation, or switching the
+ * session to full access, satisfies the gate.
+ */
+
+import { existsSync } from 'node:fs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'gitbash-executor'
+
+/** Required host services; ordering matters because apply() reads them eagerly. */
+export const inject = ['subprocess', 'sandboxPolicy']
+
+/** Node's maximum timer delay before setTimeout clamps to 1ms. */
+const MAX_TIMER_DELAY_MS = 2147483647
+
+const ENV_OVERRIDES = {
+  NO_COLOR: '1',
+  TERM: 'dumb',
+  PAGER: 'cat',
+  GIT_PAGER: 'cat',
+}
+
+/**
+ * Convert a Git Bash / MSYS drive path such as `/d/foo` into the Windows path
+ * `D:\foo` that Node's child_process can use as cwd or executable path.
+ * Only the single-letter drive form is converted: `/d`, `/d/`, `/d/foo`
+ * (the letter must be immediately followed by `/` or end the string), so
+ * MSYS root paths like `/usr/bin` are left untouched instead of being
+ * mangled into `U:\sr\bin`. Everything else (UNC, `D:\`, `D:/`) passes
+ * through unchanged.
+ */
+export function toWindowsPath(value) {
+  if (process.platform !== 'win32' || typeof value !== 'string' || value.length === 0) {
+    return value
+  }
+  const match = /^\/\s*([A-Za-z])(?:$|\/(.*))$/.exec(value)
+  if (match === null) return value
+  const drive = `${match[1].toUpperCase()}:`
+  const rest = match[2] ?? ''
+  if (rest === '') return `${drive}\\`
+  return `${drive}\\${rest.replace(/\//g, '\\')}`
+}
+
+/**
+ * Candidates for the Git-for-Windows bash executable, in preference order:
+ * the GIT_BASH environment variable, the standard install roots, this
+ * machine's known install location, then every `bash.exe` found on PATH.
+ */
+function shellPathCandidates(env) {
+  const candidates = [
+    env.GIT_BASH,
+    env.ProgramFiles === undefined ? undefined : `${env.ProgramFiles}\\Git\\bin\\bash.exe`,
+    env['ProgramFiles(x86)'] === undefined ? undefined : `${env['ProgramFiles(x86)']}\\Git\\bin\\bash.exe`,
+    env.LOCALAPPDATA === undefined ? undefined : `${env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`,
+    'D:\\applications\\Git\\bin\\bash.exe',
+  ]
+  if (typeof env.PATH === 'string' && env.PATH.length > 0) {
+    for (const dir of env.PATH.split(';')) {
+      if (dir.length === 0) continue
+      candidates.push(`${dir}\\bash.exe`)
+    }
+  }
+  return candidates
+}
+
+/**
+ * Resolve the shell executable to spawn. An explicit configuration wins; a
+ * POSIX host always gets `bash`. On Windows the first existing candidate is
+ * used (GIT_BASH → install roots → PATH), falling back to the bare `bash`
+ * name when nothing exists so spawn reports a resolution error.
+ */
+export function detectShellPath(explicit, env = process.env) {
+  if (process.platform !== 'win32') {
+    return typeof explicit === 'string' && explicit.length > 0 ? explicit : 'bash'
+  }
+  if (typeof explicit === 'string' && explicit.length > 0) return toWindowsPath(explicit)
+  for (const candidate of shellPathCandidates(env)) {
+    if (typeof candidate !== 'string' || candidate.length === 0) continue
+    if (existsSync(candidate)) return toWindowsPath(candidate)
+  }
+  return 'bash'
+}
+
+function positiveNumber(config, label, fallback) {
+  const value = config[label] ?? fallback
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError(`${name}: ${label} must be a positive finite number`)
+  }
+  return value
+}
+
+export function resolveConfig(config, env = process.env) {
+  const source = config ?? {}
+  const timeoutMs = positiveNumber(source, 'timeoutMs', 120000)
+  const maxTimeoutMs = positiveNumber(source, 'maxTimeoutMs', 600000)
+  const graceMs = positiveNumber(source, 'graceMs', 3000)
+  if (timeoutMs > MAX_TIMER_DELAY_MS || maxTimeoutMs > MAX_TIMER_DELAY_MS || graceMs > MAX_TIMER_DELAY_MS) {
+    throw new TypeError(`${name}: timeoutMs, maxTimeoutMs and graceMs must be no greater than ${MAX_TIMER_DELAY_MS}`)
+  }
+  return {
+    shellPath: detectShellPath(source.shellPath, env),
+    cwd: typeof source.cwd === 'string' && source.cwd.length > 0
+      ? toWindowsPath(source.cwd)
+      : undefined,
+    timeoutMs,
+    maxTimeoutMs,
+    maxOutputBytes: positiveNumber(source, 'maxOutputBytes', 64000),
+    maxSpillBytes: positiveNumber(source, 'maxSpillBytes', 64 * 1024 * 1024),
+    graceMs,
+  }
+}
+
+/** Fuse upstream cancellation with an identifiable timeout. */
+function timeoutSignal(upstream, timeoutMs) {
+  const timer = new AbortController()
+  const id = setTimeout(() => {
+    timer.abort(new Error('BASH_TIMEOUT'))
+  }, timeoutMs)
+  const signal = upstream === undefined
+    ? timer.signal
+    : AbortSignal.any([upstream, timer.signal])
+  return {
+    signal,
+    timedOut: () => timer.signal.aborted,
+    dispose: () => clearTimeout(id),
+  }
+}
+
+/** Project a settled subprocess collector into the tool result shape. */
+function finalOutput(reader) {
+  const read = reader.readFrom(0)
+  return {
+    text: read.text,
+    truncated: read.lossy,
+    ...read.spillPath === undefined ? {} : { spillPath: read.spillPath },
+  }
+}
+
+/** Wrap a spawn failure with the shell path and workdir that caused it. */
+function spawnError(shellPath, workdir, cause) {
+  return new Error(`${name}: failed to start ${shellPath} (workdir: ${workdir}): ${cause?.message ?? String(cause)}`, {
+    cause,
+  })
+}
+
+/** Register the git-bash executor as the entry-local `shell` provider. */
+export function apply(ctx, config) {
+  const resolved = resolveConfig(config)
+  const subprocess = ctx.get('subprocess')
+  if (subprocess === undefined) {
+    throw new Error(`${name}: ctx.subprocess is unavailable`)
+  }
+  const sandboxPolicy = ctx.get('sandboxPolicy')
+
+  const gateMessage = (mode) =>
+    `${name}: the Git-for-Windows bash runtime cannot start inside the "${mode ?? 'unknown'}" sandbox `
+    + '(the MSYS runtime cannot create its signal pipes under the restricted token). '
+    + 'Retry this exact command once with sandbox_permissions: "danger-full-access" plus a justification, '
+    + 'or ask the user to switch the session sandbox mode to full access.'
+
+  const spawnSpec = (spec, argv, stdoutMaxBytes, signal) => ({
+    argv,
+    cwd: spec.workdir,
+    stdio: {
+      stdin: spec.stdin !== undefined ? { data: spec.stdin } : 'ignore',
+      stdout: { maxBytes: stdoutMaxBytes, spill: { maxBytes: resolved.maxSpillBytes } },
+      stderr: { maxBytes: resolved.maxOutputBytes, spill: { maxBytes: resolved.maxSpillBytes } },
+    },
+    graceMs: resolved.graceMs,
+    signal,
+    env: {
+      ...ENV_OVERRIDES,
+      ...spec.env,
+      ...spec.dshEnv,
+    },
+  })
+
+  const spawnShell = (spec, stdoutMaxBytes, signal) => {
+    try {
+      return subprocess.spawn(spawnSpec(
+        spec,
+        [resolved.shellPath, '-c', spec.command],
+        stdoutMaxBytes,
+        signal,
+      ))
+    } catch (error) {
+      throw spawnError(resolved.shellPath, spec.workdir, error)
+    }
+  }
+
+  const executor = {
+    /** Advertise confinement so the bash tool offers per-call escalation. */
+    get sandboxMode() {
+      return sandboxPolicy === undefined ? undefined : sandboxPolicy.defaultMode
+    },
+
+    resolve(request) {
+      const timeoutMs = Math.min(request.timeoutMs ?? resolved.timeoutMs, resolved.maxTimeoutMs)
+      if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        throw new Error(`${name}: request.timeoutMs must be a positive finite number`)
+      }
+      const stdoutMaxBytes = request.stdoutMaxBytes ?? resolved.maxOutputBytes
+      if (!Number.isFinite(stdoutMaxBytes) || stdoutMaxBytes <= 0) {
+        throw new Error(`${name}: request.stdoutMaxBytes must be a positive finite number`)
+      }
+      return {
+        command: request.command,
+        workdir: toWindowsPath(request.workdir ?? resolved.cwd ?? process.cwd()),
+        timeoutMs,
+        stdoutMaxBytes,
+        ...request.signal === undefined ? {} : { signal: request.signal },
+        ...request.stdin === undefined ? {} : { stdin: request.stdin },
+        ...request.env === undefined ? {} : { env: request.env },
+        ...request.dshEnv === undefined ? {} : { dshEnv: request.dshEnv },
+        sandboxPolicy: request.sandboxPolicy ?? (sandboxPolicy?.resolve === undefined ? undefined : sandboxPolicy.resolve()),
+      }
+    },
+
+    async run(spec) {
+      const mode = spec.sandboxPolicy?.mode
+      // `undefined` means the deployment carries no sandbox policy at all.
+      if (mode !== undefined && mode !== 'danger-full-access') {
+        throw new Error(gateMessage(mode))
+      }
+      const fused = timeoutSignal(spec.signal, spec.timeoutMs)
+      try {
+        const handle = spawnShell(spec, spec.stdoutMaxBytes, fused.signal)
+        let outcome
+        try {
+          outcome = await handle.done
+        } catch (error) {
+          throw spawnError(resolved.shellPath, spec.workdir, error)
+        }
+        const stdout = finalOutput(handle.collected.stdout)
+        const stderr = finalOutput(handle.collected.stderr)
+        const timedOut = fused.timedOut()
+        const aborted = spec.signal !== undefined && spec.signal.aborted && !timedOut
+        return {
+          ...outcome,
+          timedOut,
+          aborted,
+          timeoutMs: spec.timeoutMs,
+          stdout,
+          stderr,
+          ...mode === undefined ? {} : { sandbox: { mode, denied: false } },
+        }
+      } finally {
+        fused.dispose()
+      }
+    },
+
+    start(spec) {
+      const mode = spec.sandboxPolicy?.mode
+      if (mode !== undefined && mode !== 'danger-full-access') {
+        throw new Error(gateMessage(mode))
+      }
+      const running = spawnShell(spec, resolved.maxOutputBytes, spec.signal)
+      const collected = {
+        stdout: running.collected.stdout,
+        stderr: running.collected.stderr,
+      }
+      let spawnFailureNote
+      const consumeSpawnFailure = () => {
+        const note = spawnFailureNote ?? ''
+        spawnFailureNote = undefined
+        return note
+      }
+      let stdoutOffset = 0
+      let stderrOffset = 0
+      const proc = {
+        status: 'running',
+        exitCode: null,
+        signal: null,
+        done: running.done.then((outcome) => {
+          if (proc.status === 'running') {
+            proc.status = spec.signal?.aborted === true || outcome.signal !== null
+              ? 'killed'
+              : 'completed'
+          }
+          proc.exitCode = outcome.exitCode
+          proc.signal = outcome.signal
+        }, (error) => {
+          proc.status = 'killed'
+          spawnFailureNote = spawnError(resolved.shellPath, spec.workdir, error).message
+        }),
+        readOutput: () => {
+          const out = collected.stdout.readFrom(stdoutOffset)
+          const err = collected.stderr.readFrom(stderrOffset)
+          stdoutOffset = out.nextOffset
+          stderrOffset = err.nextOffset
+          const errText = err.text.length > 0 ? err.text : consumeSpawnFailure()
+          const separator = out.text.length > 0 && !out.text.endsWith('\n') ? '\n' : ''
+          return {
+            delta: out.text + (errText.length > 0 ? `${separator}[stderr]\n${errText}` : ''),
+            lossy: out.lossy || err.lossy,
+            ...out.spillPath === undefined ? {} : { stdoutSpillPath: out.spillPath },
+            ...err.spillPath === undefined ? {} : { stderrSpillPath: err.spillPath },
+          }
+        },
+        kill: () => {
+          if (proc.status !== 'running') return false
+          proc.status = 'killed'
+          running.terminate()
+          return true
+        },
+      }
+      return proc
+    },
+  }
+
+  ctx.provide('shell', executor)
+}

--- a/preset/gitbash-tool.mjs
+++ b/preset/gitbash-tool.mjs
@@ -1,0 +1,129 @@
+/**
+ * gitbash-tool — the Windows `bash` tool for presets backed by
+ * gitbash-executor.mjs, with the MINIMAL-compatible model surface.
+ *
+ * The first-request trajectory anchor keys on the API-visible bash schema and
+ * description, so this tool registers `bash` with exactly `command` + optional
+ * `workdir` and a Minimal-style description. The ENGINE remains
+ * gitbash-executor — Git Bash auto-detection, MSYS path conversion for
+ * workdir, full-access sandbox gate, bounded/spilled output, timeout and
+ * grace handling — so the model surface and the execution backend are
+ * decoupled. The plugin uses a raw `ctx.tools.register()` definition (like
+ * `custom-bash.mjs`) so it has no package dependency.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'gitbash-tool'
+
+/** The entry-local shell executor and the tools registry must exist. */
+export const inject = ['shell', 'tools']
+
+const DEFAULT_TIMEOUT_MS = 120000
+const DEFAULT_MAX_OUTPUT_BYTES = 64000
+
+function positiveInt(value, field, fallback) {
+  if (value === undefined) return fallback
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name}: ${field} must be a positive safe integer`)
+  }
+  return value
+}
+
+/** Register the model-facing `bash` tool on top of the gitbash executor. */
+export function apply(ctx, config = {}) {
+  const timeoutMs = positiveInt(config.timeoutMs, 'timeoutMs', DEFAULT_TIMEOUT_MS)
+  const stdoutMaxBytes = positiveInt(config.maxOutputBytes, 'maxOutputBytes', DEFAULT_MAX_OUTPUT_BYTES)
+  const shell = ctx.shell
+  if (shell === undefined) {
+    throw new Error(`${name}: ctx.shell is unavailable`)
+  }
+  const defaultMode = shell.sandboxMode
+  const sandboxPolicy = defaultMode === undefined ? undefined : ctx.get('sandboxPolicy')
+  if (defaultMode !== undefined && sandboxPolicy === undefined) {
+    throw new Error(`${name}: the mounted bash executor confines but ctx.sandboxPolicy is missing`)
+  }
+
+  /**
+   * Resolve the session's STANDING sandbox policy before execution. The
+   * session-level preset switch is durable (`sandbox/mode` events), so the
+   * executor's `sandboxPolicy.resolve()` MUST be given the calling session;
+   * resolving without one only sees the deployment default and wrongly
+   * rejects a session that already switched to full access.
+   */
+  const resolveSandboxPolicy = (exec) => sandboxPolicy === undefined
+    ? undefined
+    : sandboxPolicy.resolve(exec?.agent === undefined ? {} : { session: exec.agent.session })
+
+  ctx.tools.register({
+    name: 'bash',
+    description: [
+      'Run commands in a bash shell (Git Bash on Windows)',
+      '* When invoking this tool, the contents of the "command" parameter does NOT need to be XML-escaped.',
+      "* You don't have access to the internet via this tool.",
+      '* You do have access to a mirror of common linux and python packages via apt and pip.',
+      '* State does NOT persist across command calls: each call runs in a fresh shell.',
+      "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
+      '* Please avoid commands that may produce a very large amount of output.',
+      '* NOTE: the MSYS runtime requires the full-access sandbox; it cannot start under restricted modes.',
+    ].join('\n'),
+    parameters: {
+      type: 'object',
+      properties: {
+        command: {
+          type: 'string',
+          description: 'The bash command to execute (`bash -c` string domain).',
+        },
+        workdir: {
+          type: 'string',
+          description: 'Optional working directory; defaults to the session cwd.',
+        },
+      },
+      required: ['command'],
+      additionalProperties: false,
+    },
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          text: { type: 'string' },
+        },
+        required: ['text'],
+      },
+      render: (_args, value) => [{ type: 'text', text: value.text }],
+    },
+    async execute(args, exec) {
+      const command = typeof args.command === 'string' ? args.command : ''
+      if (command.trim().length === 0) throw new Error('command must be a non-empty string')
+      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+        ? args.workdir
+        : exec?.agent?.session?.header?.cwd
+      const standingPolicy = resolveSandboxPolicy(exec)
+      const request = {
+        command,
+        ...workdir !== undefined ? { workdir } : {},
+        timeoutMs,
+        stdoutMaxBytes,
+        ...standingPolicy === undefined ? {} : { sandboxPolicy: standingPolicy },
+      }
+      const spec = shell.resolve(request)
+      const result = await shell.run({
+        ...spec,
+        ...exec?.signal !== undefined ? { signal: exec.signal } : {},
+      })
+
+      if (result.aborted === true) throw new Error('bash call aborted')
+      const stdout = result.stdout?.text ?? ''
+      const stderr = result.stderr?.text ?? ''
+      const text = [stdout, stderr].filter(part => part.length > 0).join('\n')
+      if (result.timedOut === true) {
+        throw new Error(`bash timed out after ${result.timeoutMs}ms${text.length > 0 ? `:\n${text}` : ''}`)
+      }
+      if (result.exitCode !== 0) {
+        const tail = text.length > 0 ? text : `exit code: ${result.exitCode} (no output)`
+        throw new Error(tail)
+      }
+      return { text }
+    },
+  })
+}

--- a/preset/msys-path-bridge.mjs
+++ b/preset/msys-path-bridge.mjs
@@ -1,0 +1,166 @@
+/**
+ * msys-path-bridge — translate MSYS drive paths (`/c/...`, `/d/...`) into
+ * Windows-native paths (`C:\...`, `D:\...`) at the TOOL REGISTRY layer.
+ *
+ * Git Bash models naturally produce `/c/Users/...` paths, while the harness's
+ * file tools (`read`, `write`, `edit`, `grep`, `glob`, `read_image`, and the
+ * bootstrap `str_replace_editor`) run against the Windows filesystem seam and
+ * would resolve `/c/...` as `C:\c\...`. This plugin wraps those tool
+ * definitions so path arguments are normalized before the original body
+ * executes; schemas and descriptions are inherited unchanged, so the model
+ * sees the original surface.
+ *
+ * Any single-letter MSYS drive path is translated (`/c`, `/d`, `/e`, ...);
+ * MSYS root paths (`/usr`, `/tmp`), relative paths, UNC paths, and
+ * Windows-native paths (`C:\...`, `C:/...`) pass through untouched.
+ *
+ * Two wrap paths are needed:
+ *  - Host-plane tools (read/write/edit/grep/glob/read_image) live in the
+ *    global tools layer, so a same-name wrapper registered through this
+ *    preset's scope shadows them for every agent joined to the preset.
+ *  - The bootstrap `str_replace_editor` registers into THIS preset's own
+ *    layer, so a same-name shadow would collide. Its stored definition is
+ *    wrapped in place instead: the registry dispatches `tool.execute` off the
+ *    stored object at call time.
+ */
+
+import { toWindowsPath } from './gitbash-executor.mjs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'msys-path-bridge'
+
+/** Tools registry must exist before wrapping can start. */
+export const inject = ['tools']
+
+/** Path-typed argument names for the tools this bridge understands. */
+const PATH_FIELDS = {
+  read: ['file_path'],
+  write: ['file_path'],
+  edit: ['file_path'],
+  read_image: ['file_path'],
+  grep: ['path'],
+  glob: ['path'],
+  str_replace_editor: ['path'],
+}
+
+/**
+ * Marker distinguishing an already-wrapped tool from the original. A
+ * process-global symbol rather than a module-local one: several preset mounts
+ * load their own copy of this plugin, and only the first should wrap a shared
+ * host-plane tool definition.
+ */
+const WRAPPED = Symbol.for('msys-path-bridge-wrapped')
+
+/**
+ * Read the dsh-scope tag off the context WITHOUT relying on the imported
+ * `scopeOf` symbol: the harness and the preset may resolve different physical
+ * copies of dsh-scope (each copy mints its own module-local symbol), so the
+ * actual key must be read from the context itself. The tag is an own property
+ * of one of the context's prototype ancestors.
+ */
+function scopeKeyOf(ctx) {
+  let depth = 0
+  for (let cursor = ctx; cursor !== null && cursor !== undefined && depth < 16; cursor = Object.getPrototypeOf(cursor), depth += 1) {
+    for (const symbol of Object.getOwnPropertySymbols(cursor)) {
+      if (symbol.description === 'dsh.scope') return cursor[symbol]
+    }
+  }
+  return undefined
+}
+
+function normalizeArgs(original, args) {
+  const fields = PATH_FIELDS[original.name]
+  if (fields === undefined || args === null || typeof args !== 'object') return args
+  let changed = false
+  const normalized = { ...args }
+  for (const field of fields) {
+    if (typeof normalized[field] !== 'string') continue
+    const converted = toWindowsPath(normalized[field])
+    if (converted !== normalized[field]) {
+      normalized[field] = converted
+      changed = true
+    }
+  }
+  return changed ? normalized : args
+}
+
+/**
+ * Build a preset-scope shadow of a global tool. `original` is already a
+ * registered ToolDefinition: its `parameters` and `output.schema` are
+ * compiled JSON Schema, NOT the authoring DSL accepted by `defineTool()`.
+ * They are therefore carried over verbatim and only `execute` is replaced.
+ */
+function wrap(original) {
+  const tool = {
+    ...original,
+    async execute(args, exec) {
+      return original.execute(normalizeArgs(original, args), exec)
+    },
+  }
+  tool[WRAPPED] = true
+  return tool
+}
+
+/**
+ * Rewrite the REGISTERED definition's execute body in place. This is the
+ * fallback for tools that live in the SAME scope layer as this plugin (the
+ * bootstrap `str_replace_editor` registers through this preset's own layer):
+ * a same-name shadow registration would throw "already registered", but the
+ * registry dispatches `tool.execute` off the stored definition object at call
+ * time, so replacing that one property wraps the existing entry.
+ */
+function wrapInPlace(original) {
+  if (original[WRAPPED] === true) return false
+  const fields = PATH_FIELDS[original.name]
+  if (fields === undefined || typeof original.execute !== 'function') return false
+  const execute = original.execute
+  original.execute = async (args, exec) => execute(normalizeArgs(original, args), exec)
+  original[WRAPPED] = true
+  return true
+}
+
+export function apply(ctx, config = {}) {
+  if (process.platform !== 'win32') return
+
+  const requested = Array.isArray(config.tools) && config.tools.length > 0
+    ? config.tools
+    : Object.keys(PATH_FIELDS)
+  const wanted = new Set(requested.filter(name => name in PATH_FIELDS))
+  const wrapped = new Set()
+  const scope = scopeKeyOf(ctx)
+
+  const wrapAvailable = () => {
+    for (const name of wanted) {
+      if (wrapped.has(name)) continue
+      const original = ctx.tools.get(name, scope)
+      if (original === undefined) continue
+      if (original[WRAPPED] === true) {
+        wrapped.add(name)
+        continue
+      }
+      if (typeof original.execute !== 'function') {
+        wrapped.add(name)
+        continue
+      }
+      try {
+        ctx.tools.register(wrap(original))
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        if (!message.includes('already registered')) throw error
+        wrapInPlace(original)
+      }
+      wrapped.add(name)
+    }
+  }
+
+  // Registration order between rows is concurrent: originals may appear after
+  // this plugin applies. Try immediately, retry on a short schedule, and retry
+  // on every `tools/change` emission.
+  queueMicrotask(wrapAvailable)
+  for (const ms of [10, 100, 1000]) {
+    setTimeout(() => wrapAvailable(), ms)
+  }
+  ctx.on('tools/change', () => {
+    wrapAvailable()
+  })
+}

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -220,10 +220,23 @@ export function apply(ctx, config) {
    * them. The event's `arguments` is the raw JSON string the model produced;
    * we parse it defensively and read the `toolNames` array.
    */
+/**
+ * Events this session produced itself. `header.seedLength` is the durable
+ * fork-lineage boundary: forked sessions replay parent history below that seq,
+ * so only events at or after it count toward THIS session's anchors/unlocks.
+ */
+function ownedEvents(session) {
+  const events = session?.events
+  if (events === undefined) return []
+  const seedLength = Number(session.header?.seedLength ?? 0)
+  if (seedLength <= 0) return events
+  return events.filter(event => event.seq === undefined || event.seq >= seedLength)
+}
+
   const unlockedFor = (session) => {
     const unlocked = new Set()
     if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    for (const event of ownedEvents(session)) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -113,7 +113,7 @@ const PROMOTE_EVENTS = {
 }
 
 /** Every config key this plugin accepts — anything else is a typo. */
-const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools'])
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools', 'promotedCatalog'])
 
 /**
  * Context sources stripped from the first request by default. Both are
@@ -150,6 +150,13 @@ function parsePromoteOn(value) {
   if (value === undefined || value === 'either') return PROMOTE_EVENTS.either
   if (value === 'tool-call' || value === 'assistant-message') return PROMOTE_EVENTS[value]
   throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
+}
+
+/** Promoted catalog mode: resident by default, `full` restores the full dump. */
+function parsePromotedCatalog(value) {
+  if (value === undefined || value === 'resident') return 'resident'
+  if (value === 'full') return 'full'
+  throw new TypeError(`${name}: promotedCatalog must be "resident" or "full"; got ${JSON.stringify(value)}`)
 }
 
 /**
@@ -199,6 +206,7 @@ export function apply(ctx, config) {
   // means "no compaction recovery catalog": the session stays on the
   // bootstrap pair until a new promotion signal.
   const compactionTools = stringListOrEmpty(source.compactionTools, 'compactionTools')
+  const promotedCatalog = parsePromotedCatalog(source.promotedCatalog)
 
   const promotion = createEpochPromotion(promoteEvents)
   ctx.on('session/event', (session, event) => promotion.observe(session, event))
@@ -275,10 +283,12 @@ function ownedEvents(session) {
     try {
       const status = promotion.status(context.agent)
       if (status.promoted) {
-        // PROMOTED: keep the minimal resident set — the bootstrap pair + the
-        // discovery tools + whatever the model explicitly unlocked via
+        // `promotedCatalog: full` restores the previous full-dump behavior;
+        // the default keeps the minimal resident set — the bootstrap pair +
+        // the discovery tools + whatever the model explicitly unlocked via
         // dev_tool_search — instead of dumping the whole Standard catalog at
         // once (the post-promotion regression fix; see the header note).
+        if (promotedCatalog === 'full') return assembled
         const keep = new Set([...bootstrapTools, ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session)])
         return keepTools(assembled, keep, false)
       }

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -113,7 +113,7 @@ const PROMOTE_EVENTS = {
 }
 
 /** Every config key this plugin accepts — anything else is a typo. */
-const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools', 'promotedCatalog'])
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools', 'promotedCatalog', 'deferSources'])
 
 /**
  * Context sources stripped from the first request by default. Both are
@@ -186,6 +186,45 @@ function optionalPositiveInt(value, field) {
   return value
 }
 
+function sourceMatcherList(value, field) {
+  if (value === undefined || (Array.isArray(value) && value.length === 0)) return []
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${name}: ${field} must be an array of source matchers`)
+  }
+  return value.map((item, index) => {
+    const at = `${field}[${index}]`
+    if (typeof item === 'string') {
+      if (item.length === 0) throw new TypeError(`${name}: ${at} kind must be a non-empty string`)
+      return { kind: item }
+    }
+    if (item === null || typeof item !== 'object') {
+      throw new TypeError(`${name}: ${at} must be a source kind string or a { kind, plugin?, form? } object`)
+    }
+    if (typeof item.kind !== 'string' || item.kind.length === 0) {
+      throw new TypeError(`${name}: ${at}.kind must be a non-empty string`)
+    }
+    const matcher = { kind: item.kind }
+    for (const key of ['plugin', 'form']) {
+      if (item[key] === undefined) continue
+      if (typeof item[key] !== 'string' || item[key].length === 0) {
+        throw new TypeError(`${name}: ${at}.${key} must be a non-empty string`)
+      }
+      matcher[key] = item[key]
+    }
+    return matcher
+  })
+}
+
+function matchesDeferredSource(message, matchers) {
+  const source = message?.source
+  if (source === undefined) return false
+  return matchers.some(matcher =>
+    source.kind === matcher.kind
+    && (matcher.plugin === undefined || source.plugin === matcher.plugin)
+    && (matcher.form === undefined || source.form === matcher.form),
+  )
+}
+
 /** Register the per-session bootstrap filters. */
 export function apply(ctx, config) {
   const source = config === undefined ? {} : config
@@ -207,6 +246,7 @@ export function apply(ctx, config) {
   // bootstrap pair until a new promotion signal.
   const compactionTools = stringListOrEmpty(source.compactionTools, 'compactionTools')
   const promotedCatalog = parsePromotedCatalog(source.promotedCatalog)
+  const deferredSources = sourceMatcherList(source.deferSources, 'deferSources')
 
   const promotion = createEpochPromotion(promoteEvents)
   ctx.on('session/event', (session, event) => promotion.observe(session, event))
@@ -228,18 +268,18 @@ export function apply(ctx, config) {
    * them. The event's `arguments` is the raw JSON string the model produced;
    * we parse it defensively and read the `toolNames` array.
    */
-/**
- * Events this session produced itself. `header.seedLength` is the durable
- * fork-lineage boundary: forked sessions replay parent history below that seq,
- * so only events at or after it count toward THIS session's anchors/unlocks.
- */
-function ownedEvents(session) {
-  const events = session?.events
-  if (events === undefined) return []
-  const seedLength = Number(session.header?.seedLength ?? 0)
-  if (seedLength <= 0) return events
-  return events.filter(event => event.seq === undefined || event.seq >= seedLength)
-}
+  /**
+   * Events this session produced itself. `header.seedLength` is the durable
+   * fork-lineage boundary: forked sessions replay parent history below that
+   * seq, so only events at or after it count toward THIS session's unlocks.
+   */
+  const ownedEvents = (session) => {
+    const events = session?.events
+    if (events === undefined) return []
+    const seedLength = Number(session.header?.seedLength ?? 0)
+    if (seedLength <= 0) return events
+    return events.filter(event => event.seq === undefined || event.seq >= seedLength)
+  }
 
   const unlockedFor = (session) => {
     const unlocked = new Set()
@@ -345,13 +385,37 @@ function ownedEvents(session) {
     const decision = await next()
     if (decision.kind === 'reject') return decision
     try {
-      if (promotion.status(agent).promoted || suppressedSources.size === 0) return decision
+      if (promotion.status(agent).promoted) return decision
       if (!Array.isArray(decision.messages)) return decision
-      const kept = decision.messages.filter((message) => {
-        const kind = message?.source?.kind
-        return typeof kind !== 'string' || !suppressedSources.has(kind)
-      })
-      return kept.length === decision.messages.length ? decision : { ...decision, messages: kept }
+      const original = decision.messages
+
+      let messages = original
+      if (suppressedSources.size > 0) {
+        const kept = messages.filter((message) => {
+          const kind = message?.source?.kind
+          return typeof kind !== 'string' || !suppressedSources.has(kind)
+        })
+        if (kept.length < messages.length) messages = kept
+      }
+
+      // Re-queue configured plugin recall injections (memory / document
+      // knowledge providers) for the NEXT step instead of polluting request #1. If the
+      // deferred messages are the only remaining input, admit them unchanged
+      // so the step loop cannot deadlock.
+      const deferred = messages.filter((message) => matchesDeferredSource(message, deferredSources))
+      if (deferred.length > 0) {
+        const kept = messages.filter((message) => !deferred.includes(message))
+        if (kept.length === 0) {
+          messages = messages
+        } else {
+          for (const message of deferred.toReversed()) {
+            agent.inbox.prepend('next-step', message)
+          }
+          messages = kept
+        }
+      }
+
+      return messages.length === original.length ? decision : { ...decision, messages }
     } catch (error) {
       // A filter bug must never eat context: degrade to keeping every message.
       warnOnce(`${name}: pre-step context filter failed, keeping injected context: ${String((error && error.message) || error)}`)

--- a/test/compaction-epoch.test.mjs
+++ b/test/compaction-epoch.test.mjs
@@ -94,3 +94,51 @@ test('a session header without delegationDepth is treated as top-level', () => {
   const s = session([], {})
   assert.equal(promotion.status({ session: s }).promoted, false)
 })
+
+test('forked sessions ignore inherited parent events below seedLength on cold scan', () => {
+  const promotion = createEpochPromotion(['tool/call', 'assistant/message'])
+  const forked = {
+    id: 'forked',
+    header: { seedLength: 1 },
+    events: [
+      { seq: 0, type: 'assistant/message', data: {} },
+      { seq: 1, type: 'tool/call', data: {} },
+    ],
+  }
+  const status = promotion.status({ session: forked })
+  assert.equal(status.promoted, true)
+  assert.equal(status.boundary, -1)
+})
+
+test('forked sessions ignore inherited parent events below seedLength incrementally', () => {
+  const promotion = createEpochPromotion(['assistant/message'])
+  const forked = { id: 'forked', header: { seedLength: 2 }, events: [] }
+  assert.equal(promotion.status({ session: forked }).promoted, false)
+  promotion.observe(forked, { seq: 1, type: 'assistant/message', data: {} })
+  assert.equal(promotion.status({ session: forked }).promoted, false)
+  promotion.observe(forked, { seq: 2, type: 'assistant/message', data: {} })
+  assert.equal(promotion.status({ session: forked }).promoted, true)
+})
+
+test('a compaction inherited from the parent below seedLength is ignored', () => {
+  const promotion = createEpochPromotion(['assistant/message'])
+  const forked = {
+    id: 'forked',
+    header: { seedLength: 2 },
+    events: [
+      { seq: 0, type: 'assistant/message', data: {} },
+      { seq: 1, type: 'compaction/end' },
+    ],
+  }
+  const status = promotion.status({ session: forked })
+  assert.equal(status.promoted, false)
+  assert.equal(status.boundary, -1)
+})
+
+test('promotion state is keyed by session object, not session id', () => {
+  const promotion = createEpochPromotion(['assistant/message'])
+  const promoted = { id: 'same-id', events: [{ type: 'assistant/message' }], header: {} }
+  const fresh = { id: 'same-id', events: [], header: {} }
+  assert.equal(promotion.status({ session: promoted }).promoted, true)
+  assert.equal(promotion.status({ session: fresh }).promoted, false)
+})

--- a/test/context-defer.test.mjs
+++ b/test/context-defer.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../zero-anchored-standard/context-defer.mjs'
+
+function register(config = {}) {
+  const listeners = {}
+  const ctx = {
+    on(event, callback, options) {
+      listeners[event] = { callback, options }
+    },
+    logger: { warn(message) {} },
+  }
+  apply(ctx, config)
+  return listeners
+}
+
+function emit(listeners, session, event) {
+  listeners['session/event'].callback(session, event)
+}
+
+function inbox() {
+  const queue = []
+  return { queue, prepend(target, message) { queue.unshift(message) } }
+}
+
+async function preStep(listener, session, decision, agentInbox = inbox()) {
+  const result = await listener.callback({ agent: { session, inbox: agentInbox } }, async () => decision)
+  return { result, inbox: agentInbox }
+}
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'context-defer')
+})
+
+test('re-queues matching recall messages until promotion', async () => {
+  const listeners = register({
+    promoteOn: 'assistant-message',
+    deferSources: [{ kind: 'plugin', plugin: 'example.recall-provider', form: 'recall' }],
+  })
+  const listener = listeners['agent/pre-step']
+  const user = { id: 'u', source: { kind: 'user' } }
+  const recall = { id: 'r', source: { kind: 'plugin', plugin: 'example.recall-provider', form: 'recall' } }
+  const session = { events: [], header: {} }
+  const first = await preStep(listener, session, { kind: 'enter', messages: [user, recall] })
+  assert.deepEqual(first.result.messages, [user])
+  assert.deepEqual(first.inbox.queue, [recall])
+  const promotion = { type: 'assistant/message' }
+  session.events.push(promotion)
+  emit(listeners, session, promotion)
+  const promoted = await preStep(listener, session, { kind: 'enter', messages: [user, recall] })
+  assert.deepEqual(promoted.result.messages, [user, recall])
+  assert.deepEqual(promoted.inbox.queue, [])
+})
+
+test('deferred-only input is admitted instead of looping', async () => {
+  const listener = register({
+    promoteOn: 'assistant-message',
+    deferSources: [{ kind: 'plugin' }],
+  })['agent/pre-step']
+  const recall = { id: 'r', source: { kind: 'plugin' } }
+  const { result, inbox: agentInbox } = await preStep(listener, { events: [], header: {} }, { kind: 'enter', messages: [recall] })
+  assert.deepEqual(result.messages, [recall])
+  assert.deepEqual(agentInbox.queue, [])
+})
+
+test('compaction resets promotion so recalls are deferred again', async () => {
+  const listeners = register({
+    promoteOn: 'assistant-message',
+    deferSources: [{ kind: 'plugin' }],
+  })
+  const listener = listeners['agent/pre-step']
+  const recall = { id: 'r', source: { kind: 'plugin' } }
+  const user = { id: 'u', source: { kind: 'user' } }
+  const session = { events: [{ seq: 1, type: 'assistant/message' }], header: {} }
+
+  const promoted = await preStep(listener, session, { kind: 'enter', messages: [user, recall] })
+  assert.deepEqual(promoted.result.messages, [user, recall])
+
+  const compaction = { seq: 2, type: 'compaction/end' }
+  session.events.push(compaction)
+  emit(listeners, session, compaction)
+  const controlled = await preStep(listener, session, { kind: 'enter', messages: [user, recall] })
+  assert.deepEqual(controlled.result.messages, [user])
+  assert.deepEqual(controlled.inbox.queue, [recall])
+})
+
+test('invalid config fails at apply time', () => {
+  assert.throws(() => register({ promoteOn: 'bogus' }), /promoteOn/)
+  assert.throws(() => register({ deferSources: [{ kind: '' }] }), /deferSources/)
+})

--- a/test/gitbash-executor.test.mjs
+++ b/test/gitbash-executor.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { join as winJoin } from 'node:path/win32'
+import { detectShellPath, name, resolveConfig, toWindowsPath } from '../preset/gitbash-executor.mjs'
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'gitbash-executor')
+})
+
+test('toWindowsPath converts MSYS drive paths on win32', { skip: process.platform !== 'win32' }, () => {
+  assert.equal(toWindowsPath('/c/Users/10531'), winJoin('C:', 'Users', '10531'))
+  assert.equal(toWindowsPath('/d/foo/bar.txt'), winJoin('D:', 'foo', 'bar.txt'))
+})
+
+test('toWindowsPath is a no-op outside win32', { skip: process.platform === 'win32' }, () => {
+  assert.equal(toWindowsPath('/c/Users/10531'), '/c/Users/10531')
+})
+
+test('detectShellPath prefers an explicit path', () => {
+  const explicit = process.platform === 'win32' ? winJoin('C:', 'Program Files', 'Git', 'bin', 'bash.exe') : '/opt/bin/bash'
+  assert.equal(detectShellPath(explicit, {}), explicit)
+})
+
+test('resolveConfig applies defaults and positive validation', () => {
+  const resolved = resolveConfig({}, {})
+  assert.equal(resolved.timeoutMs, 120000)
+  assert.equal(resolved.maxTimeoutMs, 600000)
+  assert.equal(resolved.maxOutputBytes, 64000)
+  assert.throws(() => resolveConfig({ timeoutMs: 0 }), /timeoutMs/)
+})

--- a/test/gitbash-tool.test.mjs
+++ b/test/gitbash-tool.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, inject, name } from '../preset/gitbash-tool.mjs'
+
+function register(config = {}) {
+  const registered = []
+  const resolved = []
+  const ctx = {
+    tools: {
+      register(tool) {
+        registered.push(tool)
+      },
+    },
+    shell: {
+      resolve(request) {
+        resolved.push(request)
+        return request
+      },
+      async run(spec) {
+        return {
+          exitCode: 0,
+          signal: null,
+          aborted: false,
+          timedOut: false,
+          timeoutMs: spec.timeoutMs,
+          stdout: { text: `ok:${spec.command}` },
+          stderr: { text: '' },
+        }
+      },
+    },
+  }
+  apply(ctx, config)
+  return { tool: registered[0], resolved }
+}
+
+test('exports the diagnostic plugin name and injects shell plus tools', () => {
+  assert.equal(name, 'gitbash-tool')
+  assert.deepEqual(inject, ['shell', 'tools'])
+})
+
+test('registers a Minimal-compatible bash surface', () => {
+  const { tool } = register()
+  assert.equal(tool.name, 'bash')
+  assert.deepEqual(Object.keys(tool.parameters.properties), ['command', 'workdir'])
+  assert.deepEqual(tool.parameters.required, ['command'])
+  assert.equal(tool.output.schema.type, 'object')
+  assert.equal(tool.output.schema.required[0], 'text')
+})
+
+test('executes through the shell executor and reports text', async () => {
+  const { tool, resolved } = register({ timeoutMs: 3000, maxOutputBytes: 123 })
+  const result = await tool.execute({ command: 'echo hi', workdir: '/c/Users/10531' }, {})
+  assert.deepEqual(result, { text: 'ok:echo hi' })
+  assert.equal(resolved[0].workdir, '/c/Users/10531')
+  assert.equal(resolved[0].timeoutMs, 3000)
+  assert.equal(resolved[0].stdoutMaxBytes, 123)
+})
+
+test('rejects an empty command', async () => {
+  const { tool } = register()
+  await assert.rejects(() => tool.execute({ command: '   ' }, {}), /command must be a non-empty string/)
+})
+
+test('reports non-zero exits as errors', async () => {
+  const registered = []
+  const ctx = {
+    tools: { register(tool) { registered.push(tool) } },
+    shell: {
+      resolve(request) { return request },
+      async run() {
+        return {
+          exitCode: 7,
+          aborted: false,
+          timedOut: false,
+          timeoutMs: 1000,
+          stdout: { text: 'boom' },
+          stderr: { text: '' },
+        }
+      },
+    },
+  }
+  apply(ctx, {})
+  await assert.rejects(() => registered[0].execute({ command: 'false' }, {}), /boom/)
+})
+
+test('forwards the calling session sandbox policy to the executor', async () => {
+  const registered = []
+  const resolved = []
+  const session = { id: 's1', header: { cwd: 'C:/proj' } }
+  const policy = { mode: 'danger-full-access', workspaceRoot: 'C:/proj', sessionId: 's1' }
+  const ctx = {
+    get(service) {
+      assert.equal(service, 'sandboxPolicy')
+      return {
+        resolve(request) {
+          assert.equal(request.session, session)
+          return policy
+        },
+      }
+    },
+    tools: { register(tool) { registered.push(tool) } },
+    shell: {
+      sandboxMode: 'workspace-write',
+      resolve(request) {
+        resolved.push(request)
+        return request
+      },
+      async run(spec) {
+        return {
+          exitCode: 0,
+          aborted: false,
+          timedOut: false,
+          timeoutMs: spec.timeoutMs,
+          stdout: { text: `ok:${spec.command}` },
+          stderr: { text: '' },
+        }
+      },
+    },
+  }
+  apply(ctx)
+  await registered[0].execute({ command: 'pwd' }, { agent: { session } })
+  assert.deepEqual(resolved[0].sandboxPolicy, policy)
+})
+
+test('a confining executor without sandboxPolicy fails at apply time', () => {
+  const ctx = {
+    get() { return undefined },
+    tools: { register() {} },
+    shell: { sandboxMode: 'workspace-write', resolve() {}, run() {} },
+  }
+  assert.throws(() => apply(ctx, {}), /sandboxPolicy is missing/)
+})
+
+
+test('invalid config fails at apply time', () => {
+  const ctx = {
+    tools: { register() {} },
+    shell: { resolve() {}, run() {} },
+  }
+  assert.throws(() => apply(ctx, { timeoutMs: 0 }), /timeoutMs/)
+  assert.throws(() => apply(ctx, { maxOutputBytes: -1 }), /maxOutputBytes/)
+})

--- a/test/msys-path-bridge.test.mjs
+++ b/test/msys-path-bridge.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply } from '../preset/msys-path-bridge.mjs'
+
+const kScope = Symbol('dsh.scope')
+const scopeKey = { standing: 'test' }
+
+function editorDefinition() {
+  return {
+    name: 'str_replace_editor',
+    description: 'editor',
+    parameters: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+    output: {
+      schema: { type: 'object', properties: { text: { type: 'string' } } },
+      render() {
+        return { text: '' }
+      },
+    },
+    async execute(args, exec) {
+      return { exec, args }
+    },
+  }
+}
+
+test('shadow wrap reuses compiled schemas verbatim and converts MSYS paths', { skip: process.platform !== 'win32' }, async () => {
+  const original = editorDefinition()
+  const registrations = []
+  let current = original
+  const ctx = {
+    [kScope]: scopeKey,
+    tools: {
+      get(name, scope) {
+        assert.equal(scope, scopeKey)
+        return name === current.name ? current : undefined
+      },
+      register(tool) {
+        registrations.push(tool)
+        current = tool
+      },
+    },
+    on() {},
+  }
+
+  apply(ctx, { tools: ['str_replace_editor'] })
+  await new Promise(resolve => queueMicrotask(resolve))
+
+  assert.equal(registrations.length, 1)
+  const wrapper = registrations[0]
+  assert.equal(wrapper.parameters, original.parameters)
+  assert.equal(wrapper.output, original.output)
+  const result = await wrapper.execute({ path: '/c/Users/10531/x.txt' }, 'EXEC')
+  assert.deepEqual(result.args, { path: 'C:\\Users\\10531\\x.txt' })
+  assert.equal(result.exec, 'EXEC')
+})
+
+test('same-scope duplicate falls back to in-place execute wrapping', { skip: process.platform !== 'win32' }, async () => {
+  const original = editorDefinition()
+  const firstExecute = original.execute
+  const ctx = {
+    [kScope]: scopeKey,
+    tools: {
+      get(name, scope) {
+        assert.equal(scope, scopeKey)
+        return name === original.name ? original : undefined
+      },
+      register() {
+        throw new Error('tool "str_replace_editor" is already registered in this scope')
+      },
+    },
+    on() {},
+  }
+
+  apply(ctx, { tools: ['str_replace_editor'] })
+  await new Promise(resolve => queueMicrotask(resolve))
+
+  assert.notEqual(original.execute, firstExecute)
+  const result = await original.execute({ path: '/d/work/a.txt' }, 'EXEC')
+  assert.deepEqual(result.args, { path: 'D:\\work\\a.txt' })
+  assert.equal(result.exec, 'EXEC')
+})

--- a/test/msys-paths.test.mjs
+++ b/test/msys-paths.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { toWindowsPath } from '../preset/gitbash-executor.mjs'
+
+test('converts every single-letter MSYS drive path', { skip: process.platform !== 'win32' }, () => {
+  assert.equal(toWindowsPath('/c/Users/10531'), 'C:\\Users\\10531')
+  assert.equal(toWindowsPath('/d/foo/bar.txt'), 'D:\\foo\\bar.txt')
+  assert.equal(toWindowsPath('/e'), 'E:\\')
+  assert.equal(toWindowsPath('/f/'), 'F:\\')
+  assert.equal(toWindowsPath('/C/Windows'), 'C:\\Windows')
+})
+
+test('leaves non-drive MSYS root paths untouched', () => {
+  if (process.platform !== 'win32') {
+    assert.equal(toWindowsPath('/usr/bin'), '/usr/bin')
+    return
+  }
+  assert.equal(toWindowsPath('/usr/bin'), '/usr/bin')
+  assert.equal(toWindowsPath('/tmp/x'), '/tmp/x')
+  assert.equal(toWindowsPath('/home/user'), '/home/user')
+})
+
+test('leaves Windows-native and relative paths untouched', () => {
+  assert.equal(toWindowsPath('C:\\Users\\x'), 'C:\\Users\\x')
+  assert.equal(toWindowsPath('D:/foo'), 'D:/foo')
+  assert.equal(toWindowsPath('foo/bar'), 'foo/bar')
+  assert.equal(toWindowsPath(''), '')
+  assert.equal(toWindowsPath(undefined), undefined)
+})

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -374,25 +374,38 @@ test('unknown config keys reject at apply time', () => {
   assert.throws(() => register([]), /config must be an object/)
 })
 
-test('promotedCatalog: full restores the complete catalog after promotion', async () => {
-  const { listeners } = register({ ...config, promotedCatalog: 'full' })
-  const tools = [
-    { name: 'bash' }, { name: 'str_replace_editor' },
-    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' },
-    { name: 'read' }, { name: 'edit' }, { name: 'web_search' },
-  ]
-  const first = await assemble(listeners['system-prompt/assemble'], [], tools, 'first')
-  assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
-  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools, 'promoted')
-  assert.deepEqual(promoted.tools, tools)
+test('deferSources re-queues matching plugin recalls until promotion', async () => {
+  const { listeners } = register({
+    ...config,
+    deferSources: [{ kind: 'plugin', plugin: 'example.recall-provider', form: 'recall' }],
+  })
+  const recall = { id: 'r', source: { kind: 'plugin', plugin: 'example.recall-provider', form: 'recall' } }
+  const session = { id: 'defer', events: [], header: {} }
+  const prepends = []
+  const agent = { session, inbox: { prepend(target, message) { prepends.push({ target, message }) } } }
+  const first = await listeners['agent/pre-step']({ agent }, async () => ({ kind: 'enter', messages: [userMessage, recall] }))
+  assert.deepEqual(first.messages, [userMessage])
+  assert.deepEqual(prepends.map((entry) => entry.target), ['next-step'])
+  assert.deepEqual(prepends.map((entry) => entry.message), [recall])
+
+  const promotionEvent = { type: 'tool/call' }
+  session.events.push(promotionEvent)
+  listeners['session/event'](session, promotionEvent)
+  const promoted = await listeners['agent/pre-step']({ agent }, async () => ({ kind: 'enter', messages: [userMessage, recall] }))
+  assert.deepEqual(promoted.messages, [userMessage, recall])
 })
 
-test('promotedCatalog defaults to resident and rejects invalid values', async () => {
-  const { listeners } = register()
-  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
-  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools)
-  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
-  assert.throws(() => register({ ...config, promotedCatalog: 'bogus' }), /promotedCatalog/)
+test('deferred-only input is admitted instead of looping', async () => {
+  const { listeners } = register({ ...config, deferSources: [{ kind: 'plugin' }] })
+  const session = { id: 'defer-only', events: [], header: {} }
+  const agent = { session, inbox: { prepend() { throw new Error('must not re-queue the only input') } } }
+  const decision = await listeners['agent/pre-step']({ agent }, async () => ({ kind: 'enter', messages: [pluginMessage] }))
+  assert.deepEqual(decision.messages, [pluginMessage])
+})
+
+test('invalid deferSources fail at apply time', () => {
+  assert.throws(() => register({ ...config, deferSources: [{ kind: '' }] }), /deferSources/)
+  assert.throws(() => register({ ...config, deferSources: 'plugin' }), /deferSources/)
 })
 
 test('forked sessions ignore inherited promotion and unlock events below seedLength', async () => {
@@ -429,4 +442,25 @@ test('forked sessions ignore inherited promotion and unlock events below seedLen
   const names = promoted.tools.map((tool) => tool.name)
   assert.ok(names.includes('subagent'), 'own unlock after the seed boundary is resident')
   assert.ok(!names.includes('web_search'), 'parent unlock below the seed boundary stays locked')
+})
+
+test('promotedCatalog: full restores the complete catalog after promotion', async () => {
+  const { listeners } = register({ ...config, promotedCatalog: 'full' })
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' },
+    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' },
+    { name: 'read' }, { name: 'edit' }, { name: 'web_search' },
+  ]
+  const first = await assemble(listeners['system-prompt/assemble'], [], tools, 'first')
+  assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools, 'promoted')
+  assert.deepEqual(promoted.tools, tools)
+})
+
+test('promotedCatalog defaults to resident and rejects invalid values', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools)
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  assert.throws(() => register({ ...config, promotedCatalog: 'bogus' }), /promotedCatalog/)
 })

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -89,14 +89,32 @@ test('sessions derive promotion independently from their own events', async () =
   assert.deepEqual(fresh.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
-test('promotion is memoized per session id within one process', async () => {
+test('promotion is memoized per session object within one process', async () => {
   const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'write' }]
-  const first = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools, 'memo')
+  const session = { id: 'memo', events: [{ type: 'tool/call' }], header: {} }
+  const first = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
   assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
-  // Same session id, events now empty: the cached decision still promotes.
-  const second = await assemble(listeners['system-prompt/assemble'], [], tools, 'memo')
+  // Same session object, events now empty: the cached decision still promotes.
+  session.events = []
+  const second = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
   assert.deepEqual(second.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  // A DIFFERENT session object with the same id must not inherit the cache.
+  const fresh = { id: 'memo', events: [], header: {} }
+  const third = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session: fresh } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(third.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
 })
 
 test('promoteOn tool-call requires a tool call, not just a reply', async () => {
@@ -354,4 +372,40 @@ test('unknown config keys reject at apply time', () => {
   assert.throws(() => register({ bootstrapTools: ['bash'], commonTools: ['read'] }), /unknown config key/)
   assert.throws(() => register(null), /config must be an object/)
   assert.throws(() => register([]), /config must be an object/)
+})
+
+test('forked sessions ignore inherited promotion and unlock events below seedLength', async () => {
+  const { listeners } = register()
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' },
+    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' },
+    { name: 'web_search' }, { name: 'subagent' },
+  ]
+  const session = {
+    id: 'fork',
+    header: { seedLength: 2 },
+    events: [
+      { seq: 0, type: 'assistant/message', data: {} },
+      { seq: 1, type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["web_search"]}' } },
+    ],
+  }
+  const cold = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(cold.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+
+  const ownPromotion = { seq: 2, type: 'assistant/message', data: {} }
+  const ownUnlock = { seq: 3, type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["subagent"]}' } }
+  session.events.push(ownPromotion, ownUnlock)
+  listeners['session/event'](session, ownPromotion)
+  const promoted = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  const names = promoted.tools.map((tool) => tool.name)
+  assert.ok(names.includes('subagent'), 'own unlock after the seed boundary is resident')
+  assert.ok(!names.includes('web_search'), 'parent unlock below the seed boundary stays locked')
 })

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -374,6 +374,27 @@ test('unknown config keys reject at apply time', () => {
   assert.throws(() => register([]), /config must be an object/)
 })
 
+test('promotedCatalog: full restores the complete catalog after promotion', async () => {
+  const { listeners } = register({ ...config, promotedCatalog: 'full' })
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' },
+    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' },
+    { name: 'read' }, { name: 'edit' }, { name: 'web_search' },
+  ]
+  const first = await assemble(listeners['system-prompt/assemble'], [], tools, 'first')
+  assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools, 'promoted')
+  assert.deepEqual(promoted.tools, tools)
+})
+
+test('promotedCatalog defaults to resident and rejects invalid values', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'str_replace_editor' }, { name: 'read' }]
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'tool/call' }], tools)
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  assert.throws(() => register({ ...config, promotedCatalog: 'bogus' }), /promotedCatalog/)
+})
+
 test('forked sessions ignore inherited promotion and unlock events below seedLength', async () => {
   const { listeners } = register()
   const tools = [

--- a/test/whoami-turn.test.mjs
+++ b/test/whoami-turn.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { ANCHOR_TEXT, apply, name } from '../whoami-standard/whoami-turn.mjs'
+import { apply as applyZeroBootstrap, name as zeroBootstrapName } from '../whoami-standard/zero-tool-bootstrap.mjs'
 
 function register(config = {}) {
   let listener
@@ -73,4 +74,30 @@ test('subagents are never anchored', () => {
   const { subject, prepends } = agent({ depth: 1 })
   listener({ agent: subject, message: { source: { kind: 'user' } } })
   assert.equal(prepends.length, 0)
+})
+
+test('whoami zero-tool bootstrap supports promotedCatalog: full', async () => {
+  assert.equal(zeroBootstrapName, 'zero-tool-bootstrap')
+  const listeners = {}
+  const ctx = {
+    on(event, callback) {
+      listeners[event] = callback
+    },
+    logger: { warn() {} },
+  }
+  applyZeroBootstrap(ctx, { promotedCatalog: 'full' })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+  const first = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session: { id: 's', events: [], header: {} } } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(first.tools, [])
+  const promoted = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session: { id: 's2', events: [{ type: 'assistant/message' }], header: {} } } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(promoted.tools, tools)
+  assert.throws(() => applyZeroBootstrap({ ...ctx, on() {} }, { promotedCatalog: 'bogus' }), /promotedCatalog/)
 })

--- a/test/whoami-zero-tool-bootstrap.test.mjs
+++ b/test/whoami-zero-tool-bootstrap.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../whoami-standard/zero-tool-bootstrap.mjs'
+
+function register() {
+  const listeners = {}
+  const ctx = {
+    on(event, callback) {
+      listeners[event] = callback
+    },
+    logger: { warn() {} },
+  }
+  apply(ctx, {})
+  return listeners
+}
+
+test('whoami zero-tool bootstrap exports a diagnostic plugin name', () => {
+  assert.equal(name, 'zero-tool-bootstrap')
+})
+
+test('whoami zero-tool bootstrap ignores inherited fork events below seedLength', async () => {
+  const listeners = register()
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' },
+    { name: 'dev_tool_search' }, { name: 'web_search' }, { name: 'subagent' },
+  ]
+  const session = {
+    id: 'fork',
+    header: { seedLength: 2 },
+    events: [
+      { seq: 0, type: 'assistant/message', data: {} },
+      { seq: 1, type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["web_search"]}' } },
+    ],
+  }
+  const cold = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(cold.tools, [])
+
+  const ownPromotion = { seq: 2, type: 'assistant/message', data: {} }
+  const ownUnlock = { seq: 3, type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["subagent"]}' } }
+  session.events.push(ownPromotion, ownUnlock)
+  listeners['session/event'](session, ownPromotion)
+  const promoted = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  const names = promoted.tools.map((tool) => tool.name)
+  assert.ok(names.includes('subagent'))
+  assert.ok(!names.includes('web_search'))
+})

--- a/test/zero-tool-bootstrap.test.mjs
+++ b/test/zero-tool-bootstrap.test.mjs
@@ -98,14 +98,32 @@ test('an assembly outside an agent keeps the resident catalog', async () => {
   assert.deepEqual(result.tools.map((tool) => tool.name), ['bash'])
 })
 
-test('promotion is memoized per session id within one process', async () => {
+test('promotion is memoized per session object within one process', async () => {
   const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
-  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools, {}, 'memo')
+  const session = { id: 'memo', events: [{ type: 'assistant/message', data: {} }], header: {} }
+  const promoted = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
   assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash'])
-  // Same session id, events now empty: the cached decision still promotes.
-  const again = await assemble(listeners['system-prompt/assemble'], [], tools, {}, 'memo')
+  // Same session object, events now empty: the cached decision still promotes.
+  session.events = []
+  const again = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
   assert.deepEqual(again.tools.map((tool) => tool.name), ['bash'])
+  // A DIFFERENT session object with the same id must not inherit the cache.
+  const fresh = { id: 'memo', events: [], header: {} }
+  const cold = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session: fresh } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(cold.tools, [])
 })
 
 test('sessions derive promotion independently from their own events', async () => {
@@ -143,15 +161,29 @@ test('post-compaction without compactionTools stays zero-tool until re-promotion
 test('a compaction resets promotion; a new message after the boundary re-promotes', async () => {
   const { listeners } = register()
   const tools = [{ name: 'bash' }, { name: 'read' }]
-  const events = [
-    { type: 'assistant/message', seq: 1, data: {} },
-    { type: 'compaction/end', seq: 2 },
-  ]
-  const postCompaction = await assemble(listeners['system-prompt/assemble'], events, tools)
+  const session = {
+    id: 's',
+    header: {},
+    events: [
+      { type: 'assistant/message', seq: 1, data: {} },
+      { type: 'compaction/end', seq: 2 },
+    ],
+  }
+  const postCompaction = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
   assert.deepEqual(postCompaction.tools, [])
-  // The live harness feeds new events through session/event; emulate that.
-  listeners['session/event']({ id: 's', events }, { type: 'assistant/message', seq: 3, data: {} })
-  const rePromoted = await assemble(listeners['system-prompt/assemble'], events, tools)
+  // The live harness feeds new events through session/event; emulate that on the SAME session object.
+  const rePromotion = { type: 'assistant/message', seq: 3, data: {} }
+  session.events.push(rePromotion)
+  listeners['session/event'](session, rePromotion)
+  const rePromoted = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
   assert.deepEqual(rePromoted.tools.map((tool) => tool.name), ['bash'])
 })
 
@@ -184,4 +216,40 @@ test('the pre-step strip registers with prepend', () => {
 test('invalid compactionTools values fail at apply time', () => {
   assert.throws(() => register({ compactionTools: [] }), /compactionTools/)
   assert.throws(() => register({ compactionTools: ['read', 42] }), /compactionTools/)
+})
+
+test('forked sessions ignore inherited promotion and unlock events below seedLength', async () => {
+  const { listeners } = register()
+  const tools = [
+    { name: 'bash' }, { name: 'str_replace_editor' },
+    { name: 'dev_tool_search' }, { name: 'skill_search' }, { name: 'skill_load' },
+    { name: 'web_search' }, { name: 'subagent' },
+  ]
+  const session = {
+    id: 'fork',
+    header: { seedLength: 2 },
+    events: [
+      { seq: 0, type: 'assistant/message', data: {} },
+      { seq: 1, type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["web_search"]}' } },
+    ],
+  }
+  const cold = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  assert.deepEqual(cold.tools, [])
+
+  const ownPromotion = { seq: 2, type: 'assistant/message', data: {} }
+  const ownUnlock = { seq: 3, type: 'tool/call', data: { name: 'dev_tool_search', arguments: '{"toolNames":["subagent"]}' } }
+  session.events.push(ownPromotion, ownUnlock)
+  listeners['session/event'](session, ownPromotion)
+  const promoted = await listeners['system-prompt/assemble'](
+    undefined,
+    { agent: { session } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+  const names = promoted.tools.map((tool) => tool.name)
+  assert.ok(names.includes('subagent'), 'own unlock after the seed boundary is resident')
+  assert.ok(!names.includes('web_search'), 'parent unlock below the seed boundary stays locked')
 })

--- a/test/zero-tool-bootstrap.test.mjs
+++ b/test/zero-tool-bootstrap.test.mjs
@@ -218,6 +218,23 @@ test('invalid compactionTools values fail at apply time', () => {
   assert.throws(() => register({ compactionTools: ['read', 42] }), /compactionTools/)
 })
 
+test('promotedCatalog: full restores the complete catalog after promotion', async () => {
+  const { listeners } = register({ promotedCatalog: 'full' })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'web_search' }]
+  const first = await assemble(listeners['system-prompt/assemble'], [], tools, {}, 'first')
+  assert.deepEqual(first.tools, [])
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools, {}, 'promoted')
+  assert.deepEqual(promoted.tools, tools)
+})
+
+test('promotedCatalog defaults to resident and rejects invalid values', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }]
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools)
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash'])
+  assert.throws(() => register({ promotedCatalog: 'bogus' }), /promotedCatalog/)
+})
+
 test('forked sessions ignore inherited promotion and unlock events below seedLength', async () => {
   const { listeners } = register()
   const tools = [

--- a/test/zero-tool-bootstrap.test.mjs
+++ b/test/zero-tool-bootstrap.test.mjs
@@ -218,23 +218,6 @@ test('invalid compactionTools values fail at apply time', () => {
   assert.throws(() => register({ compactionTools: ['read', 42] }), /compactionTools/)
 })
 
-test('promotedCatalog: full restores the complete catalog after promotion', async () => {
-  const { listeners } = register({ promotedCatalog: 'full' })
-  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'web_search' }]
-  const first = await assemble(listeners['system-prompt/assemble'], [], tools, {}, 'first')
-  assert.deepEqual(first.tools, [])
-  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools, {}, 'promoted')
-  assert.deepEqual(promoted.tools, tools)
-})
-
-test('promotedCatalog defaults to resident and rejects invalid values', async () => {
-  const { listeners } = register()
-  const tools = [{ name: 'bash' }, { name: 'read' }]
-  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools)
-  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash'])
-  assert.throws(() => register({ promotedCatalog: 'bogus' }), /promotedCatalog/)
-})
-
 test('forked sessions ignore inherited promotion and unlock events below seedLength', async () => {
   const { listeners } = register()
   const tools = [
@@ -269,4 +252,21 @@ test('forked sessions ignore inherited promotion and unlock events below seedLen
   const names = promoted.tools.map((tool) => tool.name)
   assert.ok(names.includes('subagent'), 'own unlock after the seed boundary is resident')
   assert.ok(!names.includes('web_search'), 'parent unlock below the seed boundary stays locked')
+})
+
+test('promotedCatalog: full restores the complete catalog after promotion', async () => {
+  const { listeners } = register({ promotedCatalog: 'full' })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'web_search' }]
+  const first = await assemble(listeners['system-prompt/assemble'], [], tools, {}, 'first')
+  assert.deepEqual(first.tools, [])
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message', data: {} }], tools, {}, 'promoted')
+  assert.deepEqual(promoted.tools, tools)
+})
+
+test('promotedCatalog defaults to resident and rejects invalid values', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }]
+  const promoted = await assemble(listeners['system-prompt/assemble'], [{ type: 'assistant/message' }], tools)
+  assert.deepEqual(promoted.tools.map((tool) => tool.name), ['bash'])
+  assert.throws(() => register({ promotedCatalog: 'bogus' }), /promotedCatalog/)
 })

--- a/whoami-standard/agent.cordis.yml
+++ b/whoami-standard/agent.cordis.yml
@@ -108,17 +108,34 @@
   name: '@deepseek-ai/dsh-tool-pwsh'
   disabled: !!js process.platform !== 'win32'
 
-# Windows-only `bash` tool (see preset/custom-bash.mjs): the official bash
-# needs a PTY, and DSH's PTY backend is linux/darwin-only. This row presents
-# the SAME tool name (`bash`) with a Minimal-compatible description but spawns
-# Git Bash through the ordinary cross-platform subprocess seam. `bashPath`
-# defaults to `bash` on PATH; point it at Git Bash explicitly when the WSL
-# shim would otherwise be picked up.
-- id: custom-bash
-  name: ../preset/custom-bash.mjs
+# Windows Git Bash shell group: shared gitbash executor + Minimal-surface bash.
+- id: gitbash-shell
+  name: cordis:group
+  group: true
   disabled: !!js process.platform !== 'win32'
+  isolate:
+    shell: true
   config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
+    - id: gitbash-executor
+      name: ../preset/gitbash-executor.mjs
+      config:
+        timeoutMs: 120000
+        maxTimeoutMs: 600000
+        maxOutputBytes: 64000
+        maxSpillBytes: 67108864
+        graceMs: 3000
+
+    - id: tool-gitbash
+      name: ../preset/gitbash-tool.mjs
+      config:
+        timeoutMs: 120000
+        maxOutputBytes: 64000
+
+# Windows-only MSYS path bridge for host file tools and the bootstrap editor.
+- id: msys-path-bridge
+  name: ../preset/msys-path-bridge.mjs
+  config:
+    tools: [read, write, edit, grep, glob, read_image, str_replace_editor]
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 

--- a/whoami-standard/zero-tool-bootstrap.mjs
+++ b/whoami-standard/zero-tool-bootstrap.mjs
@@ -109,10 +109,23 @@ export function apply(ctx, config) {
    * them. The event's `arguments` is the raw JSON string the model produced;
    * we parse it defensively and read the `toolNames` array.
    */
+/**
+ * Events this session produced itself. `header.seedLength` is the durable
+ * fork-lineage boundary: forked sessions replay parent history below that seq,
+ * so only events at or after it count toward THIS session's anchors/unlocks.
+ */
+function ownedEvents(session) {
+  const events = session?.events
+  if (events === undefined) return []
+  const seedLength = Number(session.header?.seedLength ?? 0)
+  if (seedLength <= 0) return events
+  return events.filter(event => event.seq === undefined || event.seq >= seedLength)
+}
+
   const unlockedFor = (session) => {
     const unlocked = new Set()
     if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    for (const event of ownedEvents(session)) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/whoami-standard/zero-tool-bootstrap.mjs
+++ b/whoami-standard/zero-tool-bootstrap.mjs
@@ -83,11 +83,19 @@ function sourceList(value, field, fallback) {
   return new Set(value)
 }
 
+/** Promoted catalog mode: resident by default, `full` restores the full dump. */
+function parsePromotedCatalog(value) {
+  if (value === undefined || value === 'resident') return 'resident'
+  if (value === 'full') return 'full'
+  throw new TypeError(`${name}: promotedCatalog must be "resident" or "full"; got ${JSON.stringify(value)}`)
+}
+
 /** Register the per-session bootstrap filters. */
 export function apply(ctx, config) {
   // Core work set exposed after a compaction, before re-promotion.
   const compactionTools = stringListOrEmpty(config?.compactionTools, 'compactionTools')
   const suppressedSources = sourceList(config?.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+  const promotedCatalog = parsePromotedCatalog(config?.promotedCatalog)
 
   const promotion = createEpochPromotion(['assistant/message'])
   ctx.on('session/event', (session, event) => promotion.observe(session, event))
@@ -147,10 +155,12 @@ function ownedEvents(session) {
     try {
       const status = promotion.status(context.agent)
       if (status.promoted) {
-        // PROMOTED: keep the minimal resident set — the shells +
+        // `promotedCatalog: full` restores the previous full-dump behavior;
+        // the default keeps the minimal resident set — the shells +
         // str_replace_editor + the discovery tools + whatever the model
         // explicitly unlocked via dev_tool_search — instead of dumping the
         // whole Standard catalog at once (the post-promotion regression fix).
+        if (promotedCatalog === 'full') return assembled
         const available = new Set(assembled.tools.map((tool) => tool.name))
         const keep = new Set([
           ...SHELLS.filter((name) => available.has(name)),

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -115,17 +115,34 @@
   name: '@deepseek-ai/dsh-tool-pwsh'
   disabled: !!js process.platform !== 'win32'
 
-# Windows-only `bash` tool (see preset/custom-bash.mjs): the official bash
-# needs a PTY, and DSH's PTY backend is linux/darwin-only. This row presents
-# the SAME tool name (`bash`) with a Minimal-compatible description but spawns
-# Git Bash through the ordinary cross-platform subprocess seam. `bashPath`
-# defaults to `bash` on PATH; point it at Git Bash explicitly when the WSL
-# shim would otherwise be picked up.
-- id: custom-bash
-  name: ../preset/custom-bash.mjs
+# Windows Git Bash shell group: shared gitbash executor + Minimal-surface bash.
+- id: gitbash-shell
+  name: cordis:group
+  group: true
   disabled: !!js process.platform !== 'win32'
+  isolate:
+    shell: true
   config:
-    bashPath: 'C:\Program Files\Git\bin\bash.exe'
+    - id: gitbash-executor
+      name: ../preset/gitbash-executor.mjs
+      config:
+        timeoutMs: 120000
+        maxTimeoutMs: 600000
+        maxOutputBytes: 64000
+        maxSpillBytes: 67108864
+        graceMs: 3000
+
+    - id: tool-gitbash
+      name: ../preset/gitbash-tool.mjs
+      config:
+        timeoutMs: 120000
+        maxOutputBytes: 64000
+
+# Windows-only MSYS path bridge for host file tools and the bootstrap editor.
+- id: msys-path-bridge
+  name: ../preset/msys-path-bridge.mjs
+  config:
+    tools: [read, write, edit, grep, glob, read_image, str_replace_editor]
 
 # ── filesystem ──────────────────────────────────────────────────────────────
 

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -19,6 +19,19 @@
 # pool instances — `provide()` throws on the second registration under the
 # same realm symbol; labels join REALMS, and are not what this file needs.)
 
+# ── bootstrap context (must stay FIRST) ─────────────────────────────────────
+
+# Re-queues configured plugin recall messages until the same assistant-message
+# promotion the zero anchor uses. Does NOT touch tools, output budget, or the
+# skill/instruction strip — the zero-tool bootstrap owns those concerns.
+- id: context-defer
+  name: ./context-defer.mjs
+  config:
+    promoteOn: assistant-message
+    # Ship empty: deployments add their own recall providers here, for example
+    # { kind: plugin, plugin: 'your-memory-plugin', form: recall }.
+    deferSources: []
+
 # ── identity ────────────────────────────────────────────────────────────────
 
 # Keep this text byte-identical to the Minimal preset. `complete` prevents the

--- a/zero-anchored-standard/context-defer.mjs
+++ b/zero-anchored-standard/context-defer.mjs
@@ -1,0 +1,117 @@
+/**
+ * context-defer — the `deferSources` mechanism for the zero-anchored preset.
+ *
+ * Unlike the anchored preset's tool-bootstrap, this plugin does NOT touch the
+ * tool catalog and does NOT cap output or strip the skill/instruction
+ * injections: the zero-tool bootstrap owns the zero-tool anchor turn, and this
+ * row only re-queues configured plugin recall messages (local memory /
+ * document knowledge) until the same `assistant/message` promotion the zero
+ * anchor uses.
+ *
+ * Promotion follows the same epoch-aware tracker as the zero-tool
+ * bootstrap: a `compaction/end` boundary resets promotion so deferred recalls
+ * are held back again until a NEW durable promotion signal appears past it.
+ */
+
+import { createEpochPromotion } from '../preset/compaction-epoch.mjs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'context-defer'
+
+/** Deliberately NO inject list; register this row FIRST in the composition. */
+export const inject = []
+
+const PROMOTE_EVENTS = {
+  'tool-call': ['tool/call'],
+  'assistant-message': ['assistant/message'],
+  either: ['tool/call', 'assistant/message'],
+}
+
+function parsePromoteOn(value) {
+  if (value === undefined || value === 'either') return PROMOTE_EVENTS.either
+  if (value === 'tool-call' || value === 'assistant-message') return PROMOTE_EVENTS[value]
+  throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
+}
+
+function sourceMatcherList(value, field) {
+  if (value === undefined || (Array.isArray(value) && value.length === 0)) return []
+  if (!Array.isArray(value)) {
+    throw new TypeError(`${name}: ${field} must be an array of source matchers`)
+  }
+  return value.map((item, index) => {
+    const at = `${field}[${index}]`
+    if (typeof item === 'string') {
+      if (item.length === 0) throw new TypeError(`${name}: ${at} kind must be a non-empty string`)
+      return { kind: item }
+    }
+    if (item === null || typeof item !== 'object') {
+      throw new TypeError(`${name}: ${at} must be a source kind string or a { kind, plugin?, form? } object`)
+    }
+    if (typeof item.kind !== 'string' || item.kind.length === 0) {
+      throw new TypeError(`${name}: ${at}.kind must be a non-empty string`)
+    }
+    const matcher = { kind: item.kind }
+    for (const key of ['plugin', 'form']) {
+      if (item[key] === undefined) continue
+      if (typeof item[key] !== 'string' || item[key].length === 0) {
+        throw new TypeError(`${name}: ${at}.${key} must be a non-empty string`)
+      }
+      matcher[key] = item[key]
+    }
+    return matcher
+  })
+}
+
+function matchesDeferredSource(message, matchers) {
+  const source = message?.source
+  if (source === undefined) return false
+  return matchers.some(matcher =>
+    source.kind === matcher.kind
+    && (matcher.plugin === undefined || source.plugin === matcher.plugin)
+    && (matcher.form === undefined || source.form === matcher.form),
+  )
+}
+
+export function apply(ctx, config) {
+  const promoteEvents = parsePromoteOn(config.promoteOn)
+  const deferredSources = sourceMatcherList(config.deferSources, 'deferSources')
+
+  const promotion = createEpochPromotion(promoteEvents)
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger?.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  const isPromoted = (agent) => promotion.status(agent).promoted
+
+  ctx.on('agent/pre-step', async ({ agent }, next) => {
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    try {
+      if (isPromoted(agent) || deferredSources.length === 0) return decision
+      if (!Array.isArray(decision.messages)) return decision
+      const original = decision.messages
+      const deferred = original.filter(message => matchesDeferredSource(message, deferredSources))
+      if (deferred.length === 0) return decision
+      const kept = original.filter(message => !deferred.includes(message))
+      if (kept.length === 0) {
+        return decision
+      }
+      for (const message of deferred.toReversed()) {
+        agent.inbox.prepend('next-step', message)
+      }
+      return { ...decision, messages: kept }
+    } catch (error) {
+      warnOnce(`${name}: pre-step deferral failed, keeping messages: ${String(error?.message ?? error)}`)
+      return decision
+    }
+  }, { prepend: true })
+}

--- a/zero-anchored-standard/zero-tool-bootstrap.mjs
+++ b/zero-anchored-standard/zero-tool-bootstrap.mjs
@@ -109,10 +109,23 @@ export function apply(ctx, config) {
    * them. The event's `arguments` is the raw JSON string the model produced;
    * we parse it defensively and read the `toolNames` array.
    */
+/**
+ * Events this session produced itself. `header.seedLength` is the durable
+ * fork-lineage boundary: forked sessions replay parent history below that seq,
+ * so only events at or after it count toward THIS session's anchors/unlocks.
+ */
+function ownedEvents(session) {
+  const events = session?.events
+  if (events === undefined) return []
+  const seedLength = Number(session.header?.seedLength ?? 0)
+  if (seedLength <= 0) return events
+  return events.filter(event => event.seq === undefined || event.seq >= seedLength)
+}
+
   const unlockedFor = (session) => {
     const unlocked = new Set()
     if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    for (const event of ownedEvents(session)) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/zero-anchored-standard/zero-tool-bootstrap.mjs
+++ b/zero-anchored-standard/zero-tool-bootstrap.mjs
@@ -83,11 +83,19 @@ function sourceList(value, field, fallback) {
   return new Set(value)
 }
 
+/** Promoted catalog mode: resident by default, `full` restores the full dump. */
+function parsePromotedCatalog(value) {
+  if (value === undefined || value === 'resident') return 'resident'
+  if (value === 'full') return 'full'
+  throw new TypeError(`${name}: promotedCatalog must be "resident" or "full"; got ${JSON.stringify(value)}`)
+}
+
 /** Register the per-session bootstrap filters. */
 export function apply(ctx, config) {
   // Core work set exposed after a compaction, before re-promotion.
   const compactionTools = stringListOrEmpty(config?.compactionTools, 'compactionTools')
   const suppressedSources = sourceList(config?.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+  const promotedCatalog = parsePromotedCatalog(config?.promotedCatalog)
 
   const promotion = createEpochPromotion(['assistant/message'])
   ctx.on('session/event', (session, event) => promotion.observe(session, event))
@@ -147,10 +155,12 @@ function ownedEvents(session) {
     try {
       const status = promotion.status(context.agent)
       if (status.promoted) {
-        // PROMOTED: keep the minimal resident set — the shells +
+        // `promotedCatalog: full` restores the previous full-dump behavior;
+        // the default keeps the minimal resident set — the shells +
         // str_replace_editor + the discovery tools + whatever the model
         // explicitly unlocked via dev_tool_search — instead of dumping the
         // whole Standard catalog at once (the post-promotion regression fix).
+        if (promotedCatalog === 'full') return assembled
         const available = new Set(assembled.tools.map((tool) => tool.name))
         const keep = new Set([
           ...SHELLS.filter((name) => available.has(name)),


### PR DESCRIPTION
# Summary

Combines four independently-tested improvements on top of current `main`:

1. **Fork-safe promotion and unlocks**
   `compaction-epoch` filters events through `ownedEvents()` (`seq >= header.seedLength`) and memoizes state per session object (`WeakMap`) instead of per session id. Inherited parent events can no longer promote a forked child or unlock tools from a parent's `dev_tool_search` calls.

2. **Configurable promoted catalog**
   `promotedCatalog: resident` (default) | `full`. Preserves A/B and rollback workflows without editing source.

3. **Defer plugin recall injections**
   `deferSources` matchers re-queue configured plugin recall messages to the next step until promotion. `zero-anchored-standard` gains `context-defer.mjs`. Ships with an empty matcher list; deployments add their own providers (e.g. memory / document-knowledge plugins) via YAML config. Deferred-only input is admitted unchanged to avoid empty step loops.

4. **Windows Git Bash kit**
   Replaces `custom-bash` in the Windows shell path with:
   - `gitbash-executor.mjs` — Git-for-Windows auto-detection, full-access sandbox gate (session-aware `sandboxPolicy.resolve({ session })`), bounded/spilled output, timeout handling.
   - `gitbash-tool.mjs` — Minimal surface (`command` + optional `workdir`) with no package dependency.
   - `msys-path-bridge.mjs` — converts `/c/...` / `/d/...` for file tools and the bootstrap editor.
   `custom-bash.mjs` and its tests are retained for compatibility.

# Verification

- `npm run check`: **143 passed / 0 failed / 1 skipped** (skip is the non-win32 no-op test).
- All three `agent.cordis.yml` files parse with the harness loader's `entryListSchema`.
- Windows real mount (`agentPresets.standingKeyFor`) for `anchored`, `zero-anchored`, and `whoami` presets: all **MOUNT_OK**.
- Each original feature commit was individually tested against `main`; this branch is a clean 4-commit sequence.

# Merge notes

- Suggested merge: **squash and merge** if a single upstream commit is preferred.
- No behavior changes on non-Windows platforms except the fork-safe / promotedCatalog / defer additions.
