### PR TITLE
feat: context-provider support — includeRuntimeContext + suppressedContextPlugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,6 @@ npm test
   therefore still carries the clean Minimal persona, while from request #2 on
   the model sees third-party context providers (e.g. `dsh-claude-move` Claude
   Code memory, sandbox/approval policy) that a long development session needs.
-  Measured on Project2 V4.1b (Windows, no ESP-IDF): 44/45 hidden tests, same
-  as the official Minimal run — enabling runtime context does not perturb the
-  anchor.
 - The tool catalog changes once, so request-prefix cache continuity also changes
   once between the first and second model requests.
 - The preset has the same trust level as shell access. Review its files before

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ npm test
   Standard adds over Minimal). Set the list to `[]` to disable the context
   filter; add other `source.kind` values to suppress more. A filter failure
   degrades to keeping every message rather than eating context.
+- **Context-provider support (local addition)** — the persona row runs with
+  `includeRuntimeContext: true`, and the bootstrap strips messages whose
+  `source.plugin` is listed in `suppressedContextPlugins` (this preset stamps
+  `@deepseek-ai/dsh-system-prompt`, the runtime-context snapshot). Request #1
+  therefore still carries the clean Minimal persona, while from request #2 on
+  the model sees third-party context providers (e.g. `dsh-claude-move` Claude
+  Code memory, sandbox/approval policy) that a long development session needs.
+  Measured on Project2 V4.1b (Windows, no ESP-IDF): 44/45 hidden tests, same
+  as the official Minimal run — enabling runtime context does not perturb the
+  anchor.
 - The tool catalog changes once, so request-prefix cache continuity also changes
   once between the first and second model requests.
 - The preset has the same trust level as shell access. Review its files before

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -86,8 +86,7 @@
 # first request stays Minimal-exact, while from request #2 on the model sees
 # context providers (claude-move memory, policy, etc.) that a long development
 # session needs. The bootstrap phase itself still runs with an empty context
-# surface, so the anchor is unaffected (measured: 44/45 hidden in Project2
-# V4.1b, same as official Minimal).
+# surface, so the first-request anchor is unaffected.
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -63,6 +63,13 @@
     bootstrapTools: [bash, str_replace_editor]
     promoteOn: either
     suppressedContextSources: [agent-instructions, skill-catalog]
+    # The runtime-context snapshot message (@deepseek-ai/dsh-system-prompt)
+    # is stripped while bootstrapping so request #1 carries the clean Minimal
+    # persona only, then restored after promotion. This pairs with the persona
+    # row's includeRuntimeContext: true below: third-party context providers
+    # (e.g. dsh-claude-move memory) stay visible from request #2 on without
+    # perturbing the first-request anchor.
+    suppressedContextPlugins: ['@deepseek-ai/dsh-system-prompt']
     # Post-compaction core work set: the model is mid-task and needs to keep
     # working, but faces a small catalog instead of the full Standard set.
     compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
@@ -73,12 +80,20 @@
 # Harness identity and per-tool guidance from changing the system prompt, while
 # runtime-context suppression leaves task and repository rules to user messages
 # and explicit file reads. Tool schemas and their runtime enforcement remain.
+#
+# includeRuntimeContext is flipped to true (local addition): with
+# suppressedContextPlugins stripping the runtime snapshot during bootstrap, the
+# first request stays Minimal-exact, while from request #2 on the model sees
+# context providers (claude-move memory, policy, etc.) that a long development
+# session needs. The bootstrap phase itself still runs with an empty context
+# surface, so the anchor is unaffected (measured: 44/45 hidden in Project2
+# V4.1b, same as official Minimal).
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
     text: You are a helpful software engineer assistant.
     complete: true
-    includeRuntimeContext: false
+    includeRuntimeContext: true
 
 # Instruction FILES are NOT injected (replaces dsh-agent-instructions, local
 # addition): the full AGENTS.md/CLAUDE.md digest is a large injected block

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -113,7 +113,7 @@ const PROMOTE_EVENTS = {
 }
 
 /** Every config key this plugin accepts — anything else is a typo. */
-const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools'])
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'suppressedContextPlugins', 'compactionTools'])
 
 /**
  * Context sources stripped from the first request by default. Both are
@@ -195,6 +195,12 @@ export function apply(ctx, config) {
   const promoteEvents = parsePromoteOn(source.promoteOn)
   const bootstrapMaxTokens = optionalPositiveInt(source.bootstrapMaxTokens, 'bootstrapMaxTokens')
   const suppressedSources = sourceList(source.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+  // First-step messages whose source.plugin is listed here are ALSO stripped
+  // while bootstrapping. Default empty; the preset stamps
+  // '@deepseek-ai/dsh-system-prompt' (the runtime-context snapshot) here so
+  // request #1 carries the clean Minimal persona while context providers
+  // (e.g. claude-move memory) stay visible from request #2 on.
+  const suppressedPlugins = sourceList(source.suppressedContextPlugins, 'suppressedContextPlugins', [])
   // Core work set exposed after a compaction, before re-promotion. Empty
   // means "no compaction recovery catalog": the session stays on the
   // bootstrap pair until a new promotion signal.
@@ -322,11 +328,15 @@ export function apply(ctx, config) {
     const decision = await next()
     if (decision.kind === 'reject') return decision
     try {
-      if (promotion.status(agent).promoted || suppressedSources.size === 0) return decision
+      if (promotion.status(agent).promoted || (suppressedSources.size === 0 && suppressedPlugins.size === 0)) return decision
       if (!Array.isArray(decision.messages)) return decision
       const kept = decision.messages.filter((message) => {
-        const kind = message?.source?.kind
-        return typeof kind !== 'string' || !suppressedSources.has(kind)
+        const source = message?.source
+        const kind = typeof source?.kind === 'string' ? source.kind : ''
+        if (suppressedSources.has(kind)) return false
+        const plugin = typeof source?.plugin === 'string' ? source.plugin : ''
+        if (suppressedPlugins.has(plugin)) return false
+        return true
       })
       return kept.length === decision.messages.length ? decision : { ...decision, messages: kept }
     } catch (error) {

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -178,6 +178,47 @@ test('bootstrap pre-step strips skill-catalog and agent-instructions messages', 
   assert.deepEqual(decision.messages.map((message) => message.id), ['m1'])
 })
 
+test('bootstrap pre-step strips messages from suppressedContextPlugins', async () => {
+  const { listeners } = register({ ...config, suppressedContextPlugins: ['@deepseek-ai/dsh-system-prompt'] })
+  const messages = [
+    { id: 'u', content: [{ type: 'text', text: 'user message' }] },
+    { id: 'snap', content: [{ type: 'text', text: 'runtime snapshot' }], source: { kind: 'user/message', plugin: '@deepseek-ai/dsh-system-prompt' } },
+    { id: 'k', content: [{ type: 'text', text: 'skill catalog' }], source: { kind: 'skill-catalog' } },
+    { id: 'p', content: [{ type: 'text', text: 'other plugin' }], source: { kind: 'plugin', plugin: 'other-plugin' } },
+  ]
+  const decision = await prestep(listeners['agent/pre-step'], [], messages)
+  assert.equal(decision.kind, 'enter')
+  assert.deepEqual(decision.messages.map((message) => message.id), ['u', 'p'])
+})
+
+test('suppressedContextPlugins is configurable and default-empty', async () => {
+  const { listeners } = register({ ...config, suppressedContextPlugins: ['my-plugin'] })
+  const messages = [
+    { id: 'u', content: [] },
+    { id: 'm', content: [], source: { kind: 'plugin', plugin: 'my-plugin' } },
+    { id: 'other', content: [], source: { kind: 'plugin', plugin: 'other-plugin' } },
+  ]
+  const decision = await prestep(listeners['agent/pre-step'], [], messages)
+  assert.deepEqual(decision.messages.map((message) => message.id), ['u', 'other'])
+})
+
+test('an empty suppressedContextPlugins list keeps the plugin filter off while sources still strip', async () => {
+  const { listeners } = register({ ...config, suppressedContextPlugins: [] })
+  const messages = [
+    { id: 'u', content: [] },
+    { id: 'k', content: [], source: { kind: 'skill-catalog' } },
+    { id: 'snap', content: [], source: { kind: 'user/message', plugin: '@deepseek-ai/dsh-system-prompt' } },
+  ]
+  const decision = await prestep(listeners['agent/pre-step'], [], messages)
+  // skill-catalog (source) still stripped; runtime snapshot (plugin-only) kept
+  assert.deepEqual(decision.messages.map((message) => message.id), ['u', 'snap'])
+})
+
+test('invalid suppressedContextPlugins values fail at apply time', () => {
+  assert.throws(() => register({ ...config, suppressedContextPlugins: 'x' }), /suppressedContextPlugins/)
+  assert.throws(() => register({ ...config, suppressedContextPlugins: ['x', 42] }), /suppressedContextPlugins/)
+})
+
 test('bootstrap strip preserves user skill gestures and other plugin messages', async () => {
   const { listeners } = register()
   const decision = await prestep(listeners['agent/pre-step'], [], [


### PR DESCRIPTION
## Summary

Enables third-party **context providers** (e.g. `dsh-claude-move` Claude Code memory, sandbox/approval policy) in a long development session **without perturbing the first-request anchor**:

1. `preset/agent.cordis.yml`: persona now runs with `includeRuntimeContext: true`; bootstrap stamps `suppressedContextPlugins: ['@deepseek-ai/dsh-system-prompt']` so request #1 still carries the clean Minimal persona.
2. `preset/tool-bootstrap.mjs`: new `suppressedContextPlugins` config (matches `message.source.plugin`, added to `ALLOWED_KEYS`, default empty; `[]` keeps the plugin filter off while source filtering still applies).
3. `README.md`: documents the new behavior.
4. `test/tool-bootstrap.test.mjs`: +4 tests (plugin strip, configurable, empty-list semantics, invalid values).

## Why

`includeRuntimeContext: false` (the current persona) is correct for the bootstrap phase but cuts off every context provider for the whole session. With `suppressedContextPlugins` handling the bootstrap phase explicitly, the preset gets both: a Minimal-exact request #1 **and** working memory injection afterwards — the two things long development sessions need.

## Why context injection does not affect the anchor

The anchor is decided by the **first request's** tool schema and system prompt. In this design:

- The bootstrap phase (until the first durable `tool/call` or `assistant/message`) still runs with an **empty context surface**: `suppressedContextSources` strips `skill-catalog`/`agent-instructions`, and `suppressedContextPlugins` additionally strips the runtime-context snapshot (`@deepseek-ai/dsh-system-prompt`). Request #1 therefore carries only the Minimal persona — byte-identical conditions to the pre-change preset.
- Context providers become visible **only from request #2 on**, after promotion, when the anchor has already been set. The tool schema identity (the decisive first-request variable) is unchanged.

So enabling runtime context is strictly additive to the post-promotion phase: it cannot leak into the first request, and therefore cannot change which trajectory the session anchors on. The pre-step filter also degrades to "keep everything" on failure, so a filter bug can never eat user context.

## Tests

`npm test`: 109 passed (105 existing + 4 new).