### PR TITLE
feat: let subagents inherit whoami-standard anchor flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,9 @@ real message is processed:
 
 The anchor text is configurable via the `whoami-turn` row's `text` option
 (default "你是谁"). Anchoring on the first message — not session creation —
-keeps the blank-session preset switcher usable; subagents always see the full
+keeps the blank-session preset switcher usable. With `includeSubagents: true`,
+subagents inherit the same flow: their first request is the whoami anchor with
+zero tools, and the delegated task runs on the next turn with the resident
 catalog. The trade-off is one extra model call per session: the anchor turn is
 always taken, even when the first message is urgent.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,8 +195,10 @@ cp -R zero-anchored-standard "$dsh_home/.agent-presets/zero-anchored-standard"
    发现类工具）已解锁，重型 Standard 工具一次 `dev_tool_search` 即可取用。
 
 锚定文本可通过 `whoami-turn` 行的 `text` 配置（默认"你是谁"）。锚定发生在第一条
-消息到达时而非会话创建时，新建会话仍可先切换模式；子 agent 始终看到完整目录。
-代价是每个会话固定多一次模型调用——即使第一条消息很紧急也会先跑自我介绍轮。
+消息到达时而非会话创建时，新建会话仍可先切换模式。设置 `includeSubagents: true`
+后，子 agent 也会继承同样的流程：首轮先做"你是谁"自我介绍、工具为 0，真正的委托
+任务在下一轮带着 resident 目录执行。代价是每个会话固定多一次模型调用——即使第一
+条消息很紧急也会先跑自我介绍轮。
 
 该预设通过 `../preset/` 引用与 anchored 的 `preset/` 目录共享插件模块，安装时
 请一并安装该目录（见上文"安装"章节）。

--- a/preset/compaction-epoch.mjs
+++ b/preset/compaction-epoch.mjs
@@ -15,10 +15,16 @@
  * State is memoized per session id and maintained incrementally through
  * `observe()`; a cold session scans its durable log once (so resume and
  * reload reconstruct the same phase), then O(1).
+ *
+ * By default subagents (`delegationDepth > 0`) are treated as already
+ * promoted so their first request can use tools. Set `includeSubagents: true`
+ * to make subagents follow the same bootstrap/anchor phase as top-level
+ * sessions.
  */
 
 /** Build one epoch-aware promotion tracker. */
-export function createEpochPromotion(promoteEvents) {
+export function createEpochPromotion(promoteEvents, options = {}) {
+  const includeSubagents = options.includeSubagents === true
   const promote = new Set(promoteEvents)
   /** sessionId -> { boundary, promoted } */
   const state = new Map()
@@ -53,8 +59,9 @@ export function createEpochPromotion(promoteEvents) {
       if (agent === undefined) return { boundary: -1, promoted: true }
       const session = agent.session
       if (session === undefined) return { boundary: -1, promoted: true }
-      // Subagents keep the full catalog from their very first request.
-      if ((session.header?.delegationDepth ?? 0) > 0) return { boundary: -1, promoted: true }
+      // By default subagents keep the full catalog from their very first
+      // request; includeSubagents makes them follow the normal bootstrap phase.
+      if (!includeSubagents && (session.header?.delegationDepth ?? 0) > 0) return { boundary: -1, promoted: true }
       return state.get(session.id) ?? scan(session)
     },
     /** Incremental feed: call on every `session/event`. */

--- a/test/compaction-epoch.test.mjs
+++ b/test/compaction-epoch.test.mjs
@@ -77,10 +77,17 @@ test('multiple compactions: the LAST boundary wins', () => {
   assert.equal(status.boundary, 4)
 })
 
-test('subagents (delegationDepth > 0) are always promoted', () => {
+test('subagents (delegationDepth > 0) are always promoted by default', () => {
   const promotion = createEpochPromotion(['tool/call'])
   const s = session([], { delegationDepth: 1 })
   assert.equal(promotion.status({ session: s }).promoted, true)
+})
+
+test('subagents follow the normal phase when includeSubagents is true', () => {
+  const promotion = createEpochPromotion(['tool/call'], { includeSubagents: true })
+  const s = session([], { delegationDepth: 1 })
+  assert.equal(promotion.status({ session: s }).promoted, false)
+  assert.equal(promotion.status({ session: s }).boundary, -1)
 })
 
 test('undefined agent or session is always promoted (defensive)', () => {

--- a/test/whoami-turn.test.mjs
+++ b/test/whoami-turn.test.mjs
@@ -68,9 +68,17 @@ test('sessions with a prior user message are not anchored again', () => {
   assert.equal(prepends.length, 0)
 })
 
-test('subagents are never anchored', () => {
+test('subagents are never anchored by default', () => {
   const listener = register()
   const { subject, prepends } = agent({ depth: 1 })
   listener({ agent: subject, message: { source: { kind: 'user' } } })
   assert.equal(prepends.length, 0)
+})
+
+test('subagents are anchored when includeSubagents is true', () => {
+  const listener = register({ includeSubagents: true })
+  const { subject, prepends } = agent({ depth: 1 })
+  listener({ agent: subject, message: { source: { kind: 'user' } } })
+  assert.equal(prepends.length, 1)
+  assert.equal(prepends[0].message.content[0].text, ANCHOR_TEXT)
 })

--- a/test/whoami-zero-tool-bootstrap.test.mjs
+++ b/test/whoami-zero-tool-bootstrap.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { apply, name } from '../whoami-standard/zero-tool-bootstrap.mjs'
+
+function register(config) {
+  const listeners = {}
+  const hookOptions = {}
+  const warns = []
+  const ctx = {
+    on(event, callback, options) {
+      listeners[event] = callback
+      hookOptions[event] = options
+    },
+    logger: {
+      warn(message) {
+        warns.push(message)
+      },
+    },
+  }
+  apply(ctx, config)
+  assert.equal(typeof listeners['system-prompt/assemble'], 'function')
+  return { listeners, hookOptions, warns }
+}
+
+function assemble(listener, events, tools, header = {}, id = 's') {
+  return listener(
+    undefined,
+    { agent: { session: { id, events, header } } },
+    async () => ({ system: 'minimal persona', tools }),
+  )
+}
+
+test('exports a diagnostic plugin name', () => {
+  assert.equal(name, 'zero-tool-bootstrap')
+})
+
+test('includeSubagents: true keeps subagents in the zero-tool anchor phase', async () => {
+  const { listeners } = register({ includeSubagents: true })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+  const result = await assemble(listeners['system-prompt/assemble'], [], tools, { delegationDepth: 1 })
+  assert.deepEqual(result.tools, [])
+})
+
+test('includeSubagents: true lets a subagent promote to the resident catalog after the anchor reply', async () => {
+  const { listeners } = register({ includeSubagents: true })
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }, { name: 'grep' }]
+  const result = await assemble(
+    listeners['system-prompt/assemble'],
+    [{ type: 'assistant/message', data: {} }],
+    tools,
+    { delegationDepth: 1 },
+  )
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash'])
+})
+
+test('without includeSubagents subagents stay promoted from their first request', async () => {
+  const { listeners } = register()
+  const tools = [{ name: 'bash' }, { name: 'read' }, { name: 'edit' }]
+  const result = await assemble(listeners['system-prompt/assemble'], [], tools, { delegationDepth: 1 })
+  assert.deepEqual(result.tools.map((tool) => tool.name), ['bash'])
+})

--- a/whoami-standard/agent.cordis.yml
+++ b/whoami-standard/agent.cordis.yml
@@ -54,14 +54,16 @@
 - id: dev-tool-search
   name: ../preset/dev-tool-search.mjs
 
-# V4 Pro conditions strongly on the API tool catalog. The first top-level
-# model request therefore carries ZERO tools: `whoami-turn` seeds the fixed
-# "你是谁" user message, this bootstrap strips the whole catalog, and the
-# model's self-introduction reply is the promotion signal. After that
-# assistant response is durable, later step assemblies narrow to the minimal
-# RESIDENT set (shells + str_replace_editor + the discovery tools + explicitly
-# unlocked tools) instead of the full Standard dump — the post-promotion
-# regression fix. Subagents always see the full catalog.
+# V4 Pro conditions strongly on the API tool catalog. The first model request
+# therefore carries ZERO tools: `whoami-turn` seeds the fixed "你是谁" user
+# message, this bootstrap strips the whole catalog, and the model's
+# self-introduction reply is the promotion signal. After that assistant
+# response is durable, later step assemblies narrow to the minimal RESIDENT
+# set (shells + str_replace_editor + the discovery tools + explicitly unlocked
+# tools) instead of the full Standard dump — the post-promotion regression
+# fix. Subagents also run the whoami anchor and zero-tool bootstrap
+# (`includeSubagents: true`); after the anchor reply they see the resident
+# catalog.
 #
 # The same phase gate suppresses AUTO-INJECTED context (`suppressedContextSources`,
 # default `['skill-catalog', 'agent-instructions']`) while the session is
@@ -78,6 +80,7 @@
   config:
     suppressedContextSources: [agent-instructions, skill-catalog]
     compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
+    includeSubagents: true
 
 # Seed the whoami anchor turn when the first user message arrives: the anchor
 # is prepended to the `next-turn` inbox queue ahead of the real message, and
@@ -85,11 +88,13 @@
 # request sees only "你是谁" with no tools, while the real input is claimed by
 # the NEXT turn — with the promoted resident catalog already unlocked.
 # Anchoring on first message — not session creation — keeps the blank-session
-# preset switcher usable. The anchor text is configurable via `text`.
+# preset switcher usable. The anchor text is configurable via `text`; set
+# `includeSubagents: true` so subagents also take the whoami anchor turn.
 - id: whoami-turn
   name: ./whoami-turn.mjs
   config:
     text: 你是谁
+    includeSubagents: true
 
 # ── shell ───────────────────────────────────────────────────────────────────
 

--- a/whoami-standard/preset.yml
+++ b/whoami-standard/preset.yml
@@ -1,3 +1,3 @@
 name: Whoami Standard (experimental)
-description: Seed one fixed "你是谁" (who are you) self-introduction turn on an empty tool surface, then let the user's first real message proceed on the next turn with the promoted resident catalog unlocked.
+description: Seed one fixed "你是谁" (who are you) self-introduction turn on an empty tool surface, then let the user's first real message proceed on the next turn with the promoted resident catalog unlocked. Subagents inherit the same anchor flow.
 order: 7

--- a/whoami-standard/whoami-turn.mjs
+++ b/whoami-standard/whoami-turn.mjs
@@ -12,6 +12,10 @@
  * Anchoring on the first user message — instead of at session creation — keeps
  * the blank-session preset switcher usable before the user types anything.
  *
+ * By default subagents are skipped so their first request can use tools
+ * immediately. Set `includeSubagents: true` to make subagents also take the
+ * whoami anchor turn.
+ *
  * Durability is free: the prepend goes through `agent/inbox/spliced` event
  * persistence, so a crash between the anchor and the real message resumes the
  * queue in order, and the inbox replay does not fire `inserted` notifications,
@@ -24,9 +28,9 @@ export const name = 'whoami-turn'
 /** Default anchor text shown to the model in the synthetic first user turn. */
 export const ANCHOR_TEXT = '你是谁'
 
-/** Only top-level fresh sessions (no prior user message) get the anchor turn. */
-function isFreshTopLevel(agent) {
-  if ((agent.session.header.delegationDepth ?? 0) > 0) return false
+/** Fresh sessions (no prior user message) get the anchor turn. */
+function isFreshSession(agent, includeSubagents = false) {
+  if (!includeSubagents && (agent.session.header.delegationDepth ?? 0) > 0) return false
   return !agent.session.events.some((event) => event.type === 'user/message')
 }
 
@@ -35,9 +39,10 @@ export function apply(ctx, config) {
   const text = typeof config.text === 'string' && config.text.length > 0
     ? config.text
     : ANCHOR_TEXT
+  const includeSubagents = config?.includeSubagents === true
 
   ctx.on('agent/inbox/inserted', ({ agent, message }) => {
-    if (!isFreshTopLevel(agent)) return
+    if (!isFreshSession(agent, includeSubagents)) return
     // Never re-anchor on plugin-sourced messages (including our own anchor).
     if (message.source?.kind === 'plugin') return
     agent.inbox.prepend('next-turn', {

--- a/whoami-standard/zero-tool-bootstrap.mjs
+++ b/whoami-standard/zero-tool-bootstrap.mjs
@@ -39,8 +39,9 @@
  * Robustness:
  *  - Promotion decisions are memoized per session id for this process; the
  *    durable event scan runs once per session per process, then O(1).
- *  - Subagents and non-top-level agents always see the full catalog: their
- *    first request must be able to call tools.
+ *  - By default subagents are treated as already promoted so their first
+ *    request can use tools. Set `includeSubagents: true` to make subagents
+ *    follow the same zero-tool anchor phase as top-level sessions.
  *  - A filter failure degrades to the full catalog with a one-time warning,
  *    so a bug can never brick every request of a session.
  */
@@ -89,7 +90,7 @@ export function apply(ctx, config) {
   const compactionTools = stringListOrEmpty(config?.compactionTools, 'compactionTools')
   const suppressedSources = sourceList(config?.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
 
-  const promotion = createEpochPromotion(['assistant/message'])
+  const promotion = createEpochPromotion(['assistant/message'], { includeSubagents: config?.includeSubagents === true })
   ctx.on('session/event', (session, event) => promotion.observe(session, event))
 
   let warned = false

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -57,7 +57,8 @@
 # response is durable, later step assemblies narrow to the minimal RESIDENT
 # set (shells + str_replace_editor + the discovery tools + explicitly
 # unlocked tools) instead of the full Standard dump — the post-promotion
-# regression fix. Subagents always see the full catalog.
+# regression fix. By default subagents always see the full catalog; set
+# `includeSubagents: true` to make them follow the anchor phase too.
 #
 # The same phase gate suppresses AUTO-INJECTED context (`suppressedContextSources`,
 # default `['skill-catalog', 'agent-instructions']`) while the session is

--- a/zero-anchored-standard/zero-tool-bootstrap.mjs
+++ b/zero-anchored-standard/zero-tool-bootstrap.mjs
@@ -39,8 +39,9 @@
  * Robustness:
  *  - Promotion decisions are memoized per session id for this process; the
  *    durable event scan runs once per session per process, then O(1).
- *  - Subagents and non-top-level agents always see the full catalog: their
- *    first request must be able to call tools.
+ *  - By default subagents are treated as already promoted so their first
+ *    request can use tools. Set `includeSubagents: true` to make subagents
+ *    follow the same zero-tool anchor phase as top-level sessions.
  *  - A filter failure degrades to the full catalog with a one-time warning,
  *    so a bug can never brick every request of a session.
  */
@@ -89,7 +90,7 @@ export function apply(ctx, config) {
   const compactionTools = stringListOrEmpty(config?.compactionTools, 'compactionTools')
   const suppressedSources = sourceList(config?.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
 
-  const promotion = createEpochPromotion(['assistant/message'])
+  const promotion = createEpochPromotion(['assistant/message'], { includeSubagents: config?.includeSubagents === true })
   ctx.on('session/event', (session, event) => promotion.observe(session, event))
 
   let warned = false


### PR DESCRIPTION
# feat: let subagents inherit whoami-standard anchor flow

## Summary

Make the `whoami-standard` experimental preset able to apply its whoami anchor flow to subagents as well. By default subagents are still treated as already promoted (so their first request can use tools); enabling `includeSubagents: true` makes subagents also take the "你是谁" self-introduction turn with a zero-tool surface, then run the real delegated task on the next turn with the promoted resident catalog.

## Motivation

Previously, subagents spawned from a `whoami-standard` session skipped the anchor/bootstrap entirely. Users who want the same first-turn trajectory control for delegated subagents had no way to enable it. This PR adds an opt-in configuration rather than changing the default, so existing `zero-anchored-standard` behavior and existing `whoami-standard` deployments remain unaffected unless they opt in.

## Changes

- `preset/compaction-epoch.mjs`
  - `createEpochPromotion(promoteEvents, options = {})` now accepts `options.includeSubagents`.
  - When `includeSubagents` is `true`, subagents (`delegationDepth > 0`) are no longer force-promoted; they follow the same epoch-aware bootstrap phase as top-level sessions.
- `whoami-standard/zero-tool-bootstrap.mjs`
  - Passes `includeSubagents: config?.includeSubagents === true` into `createEpochPromotion`.
- `zero-anchored-standard/zero-tool-bootstrap.mjs`
  - Same config plumbing; default remains `false`, so zero-anchored behavior is unchanged.
- `whoami-standard/whoami-turn.mjs`
  - `isFreshSession(agent, includeSubagents)` only skips subagents when `includeSubagents` is not enabled.
- `whoami-standard/agent.cordis.yml`
  - Enables `includeSubagents: true` for both `zero-tool-bootstrap` and `whoami-turn`.
- `whoami-standard/preset.yml`
  - Description now mentions that subagents inherit the anchor flow.
- `README.md`, `README.zh-CN.md`
  - Whoami Standard docs updated; Zero-Anchored docs clarify the default remains unchanged.

## Behavior

With `includeSubagents: true` in `whoami-standard`:

1. A newly spawned subagent's first model request sees only the fixed "你是谁" anchor and an empty tool catalog.
2. The subagent's self-introduction reply is the promotion signal.
3. The actual delegated prompt is processed on the next turn, with the promoted resident catalog available.

## Compatibility

- `zero-anchored-standard` keeps its current behavior by default.
- Existing `whoami-standard` sessions without `includeSubagents: true` keep the previous subagent behavior.
- No public API breaking changes; the new option is additive.

## Tests

- `test/compaction-epoch.test.mjs`
  - Keeps the default subagent-always-promoted assertion.
  - Adds `includeSubagents: true` assertion that subagents start un-promoted.
- `test/whoami-turn.test.mjs`
  - Keeps the default subagents-not-anchored assertion.
  - Adds `includeSubagents: true` assertion that subagents are anchored.
- `test/whoami-zero-tool-bootstrap.test.mjs` (new)
  - Verifies subagents get zero tools on first request, promote to resident catalog after the anchor reply, and keep the old behavior when the option is off.
- `test/zero-tool-bootstrap.test.mjs`
  - Existing subagent assertion still passes unchanged.

All 111 tests pass.

## Notes

- Subagents that inherit the anchor flow cost one extra model call (the self-introduction turn), consistent with the top-level whoami-standard behavior.
- This is an opt-in feature; users who need subagents to call tools immediately should leave `includeSubagents` unset or `false`.
