### PR TITLE
feat: 新增 dual-anchor 稳定化变体(bootstrapMaxTokens: 1024)

### DIFF
--- a/anchored-standard-dual-anchor/agent.cordis.yml
+++ b/anchored-standard-dual-anchor/agent.cordis.yml
@@ -1,0 +1,414 @@
+# The `anchored-standard` experimental preset: Standard capabilities with the
+# Minimal mode system-prompt condition used by the V4 trajectory evaluation.
+#
+# This file is an AGENT-PLANE composition. The roster mounts it ONCE under a
+# standing scope; every session naming it joins by scope parentage, so the
+# tools and prompt sections registered here cover each joined agent while a
+# session's own state stays keyed per Session/Agent inside the plugins. The
+# host composition (`base.cordis.yml` + `web.cordis.yml`) keeps everything a
+# preset must not own: the registries themselves, the sandbox and approval
+# stack, persistence, and the model route.
+#
+# A service row here MUST sit inside a group carrying an `isolate` realm.
+# Without one it publishes into the root realm, where it is process-global —
+# another preset publishing the same name collides, and a host reader would
+# resolve one preset's instance for every session; `dsh-agent-presets` rejects
+# that at mount. `true` means an entry-local realm: this standing mount's own
+# private instance, apart from every other preset's. (A shared label does NOT
+# pool instances — `provide()` throws on the second registration under the
+# same realm symbol; labels join REALMS, and are not what this file needs.)
+
+# ── bootstrap (must stay FIRST) ─────────────────────────────────────────────
+
+# This row deliberately sits before every other row: dsh-agent-instructions and
+# dsh-tool-skill inject workspace instructions and the skill catalog into the
+# first request via the agent/pre-step waterfall, and waterfall after-next
+# transforms apply in reverse registration order. Registering first (plus the
+# plugin empty inject list and the listener's `prepend` flag) makes this filter
+# strip the final transform, so request #1 stays Minimal-exact (see issue #6).
+#
+# V4 Pro conditions strongly on the API tool catalog AND the first request
+# output budget. Bootstrap request #1 with the OFFICIAL Minimal preset's real
+# tool pair — persistent `bash` + `str_replace_editor` — which anchors at the
+# adapter-default maxTokens (256000) with no output cap needed (issue #11:
+# 5/5 anchored vs 11/11 standard-like for every standard-family schema);
+# after the session records its first durable promotion signal (a tool call OR
+# the first assistant message, default `promoteOn: either`), later steps
+# narrow to the minimal RESIDENT set (see below). `bootstrapMaxTokens` is
+# opt-in for standard-schema bootstraps; unset, the adapter default flows. See
+# tool-bootstrap.mjs for the other triggers.
+#
+# The same phase gate suppresses AUTO-INJECTED context on request #1:
+# `suppressedContextSources` lists the `agent/pre-step` message sources the
+# bootstrap filter strips while the session is unpromoted. The defaults are the
+# two automatic injections Standard adds over Minimal — the available-skills
+# reminder (`skill-catalog`) and the workspace instruction digest
+# (`agent-instructions`). User-initiated skill gestures are not filtered, and
+# both injections return unchanged from request #2 on. Set the list to [] to
+# disable the context filter while keeping the tool bootstrap.
+#
+# POST-PROMOTION (local addition): the promoted catalog is NOT the full
+# Standard dump — it stays on the bootstrap pair + the three discovery tools
+# (dev_tool_search / skill_search / skill_load) + whatever the model unlocked
+# via dev_tool_search. Heavier tools are one dev_tool_search away; the
+# trajectory is not pulled back to standard-like behavior by a 25-tool dump.
+#
+# COMPACTION (local addition): after `compaction/end` the session falls back
+# to the controlled phase — bootstrap pair + `compactionTools` — until a NEW
+# durable promotion signal exists past the boundary (epoch-aware, see
+# compaction-epoch.mjs).
+#
+# DUAL-ANCHOR (this variant, issue #25): `bootstrapMaxTokens: 1024` pins the
+# first request's output budget to 1024 so the CAP anchor path runs alongside
+# the Minimal-schema anchor path — issue #11 measured "We need" style in
+# 26/32 runs at max_tokens=1024 independent of tool descriptions, while the
+# Minimal tool pair anchors 5/5 at the adapter default. Running both paths in
+# parallel keeps the anchor stable even when the adapter default maxTokens
+# drifts off 256000 (e.g. an `adapterDefaults.maxTokens` override) or the
+# Minimal schema contract breaks on a harness upgrade. The cap is stripped
+# after promotion (see tool-bootstrap.mjs).
+- id: tool-bootstrap
+  name: ./tool-bootstrap.mjs
+  config:
+    bootstrapTools: [bash, str_replace_editor]
+    promoteOn: either
+    suppressedContextSources: [agent-instructions, skill-catalog]
+    # Stabilization (issue #25): cap the first request's output budget to 1024
+    # so the cap anchor path runs alongside the Minimal-schema anchor path.
+    # Stripped after promotion by tool-bootstrap.mjs.
+    bootstrapMaxTokens: 1024
+    # Post-compaction core work set: the model is mid-task and needs to keep
+    # working, but faces a small catalog instead of the full Standard set.
+    compactionTools: [read, write, edit, glob, grep, todo_write, ask_user_question]
+
+# ── identity ────────────────────────────────────────────────────────────────
+
+# Keep this text byte-identical to the Minimal preset. `complete` prevents the
+# Harness identity and per-tool guidance from changing the system prompt, while
+# runtime-context suppression leaves task and repository rules to user messages
+# and explicit file reads. Tool schemas and their runtime enforcement remain.
+- id: persona
+  name: '@deepseek-ai/dsh-persona'
+  config:
+    text: You are a helpful software engineer assistant.
+    complete: true
+    includeRuntimeContext: false
+
+# Instruction FILES are NOT injected (replaces dsh-agent-instructions, local
+# addition): the full AGENTS.md/CLAUDE.md digest is a large injected block
+# that perturbs the trajectory even after promotion. Instead, after promotion
+# ONE short hint is injected once per session — "these instruction files
+# exist; read them before acting" — and the model reads the files itself via
+# the filesystem tools when relevant.
+- id: instruction-hint
+  name: ./instruction-hint.mjs
+  config:
+    promoteOn: either
+
+# On-demand tool discovery (the tool-search pattern, local addition): the
+# promoted catalog keeps a minimal resident set; heavier Standard tools
+# (web_search, subagent, workflow, …) are unlocked on demand via
+# dev_tool_search.
+- id: dev-tool-search
+  name: ./dev-tool-search.mjs
+
+# ── shell ───────────────────────────────────────────────────────────────────
+
+# `shell-env` stays in the HOST composition: `apps/cli/src/web.ts` injects it to
+# publish `DSH_WEB_URL`/`DSH_WEB_MODE`, and a host row that injects a service is
+# the criterion for host-plane ownership — injection resolves before any session
+# exists, so there is no agent to key by. Behind a preset realm those variables
+# never reached the model's shell at all. Both shell tools consume the host
+# registry from here; their executors (`bash-sandbox`/`pwsh-sandbox`) are
+# host-plane too.
+- id: tool-bash
+  name: '@deepseek-ai/dsh-tool-bash'
+  # Disabled on EVERY platform, not just Windows: `dsh-tool-bash-persistent`
+  # below registers the same `bash` tool name into this same preset layer, and
+  # the tools registry rejects duplicates within one layer. The persistent
+  # shell (the Minimal preset's own shell) is the preset's bash; it consumes
+  # the host sandbox policy through the terminals realm.
+  disabled: true
+
+- id: tool-pwsh
+  name: '@deepseek-ai/dsh-tool-pwsh'
+  disabled: !!js process.platform !== 'win32'
+
+# The Minimal preset's shell: a PTY-backed persistent bash, byte-identical in
+# configuration to the official `minimal` preset's `persistent-shell` group so
+# the first request exposes exactly Minimal's real `bash` schema. The PTY
+# registry is an agent-owned service, so it lives in an entry-local realm; the
+# backend still consumes the host sandbox policy and subprocess implementation,
+# while the tool registers into this agent's scoped catalog.
+#
+# DISABLED ON WINDOWS: DSH's PTY backend is linux/darwin-only, so the
+# persistent shell cannot serve win32. The `custom-bash` row below registers
+# the same `bash` tool name there instead (platform-exclusive).
+- id: persistent-shell
+  name: cordis:group
+  group: true
+  disabled: !!js process.platform === 'win32'
+  isolate:
+    terminals: true
+  config:
+    - id: pty
+      name: '@deepseek-ai/dsh-terminal'
+
+    - id: terminal-bash
+      name: '@deepseek-ai/dsh-terminal-bash'
+      config:
+        timeoutMs: 300000
+
+    - id: persistent-bash
+      name: '@deepseek-ai/dsh-tool-bash-persistent'
+      config:
+        timeoutMs: 300000
+        description: |-
+          Run commands in a bash shell
+          * When invoking this tool, the contents of the "command" parameter does NOT need to be XML-escaped.
+          * You don't have access to the internet via this tool.
+          * You do have access to a mirror of common linux and python packages via apt and pip.
+          * State is persistent across command calls and discussions with the user.
+          * To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.
+          * Please avoid commands that may produce a very large amount of output.
+          * Please run long lived commands in the background, e.g. 'sleep 10 &' or start a server in the background.
+
+# Windows-only `bash` tool (see preset/custom-bash.mjs): registers the SAME
+# tool name as the persistent shell with a Minimal-compatible description, but
+# executes through the ordinary cross-platform subprocess seam (`bash -c`)
+# instead of a PTY. `bashPath` defaults to `bash` on PATH; point it at Git
+# Bash explicitly when the WSL shim would otherwise be picked up. No OS
+# sandbox confinement on Windows (landlock is linux-only); the tool
+# description says so.
+- id: custom-bash
+  name: ./custom-bash.mjs
+  disabled: !!js process.platform !== 'win32'
+  config:
+    bashPath: 'C:\Program Files\Git\bin\bash.exe'
+
+# ── filesystem ──────────────────────────────────────────────────────────────
+
+# Both register into the host `tools` registry and provide nothing, so
+# they need no realm. The `fs` service and its policy stay in the host.
+- id: tool-fs
+  name: '@deepseek-ai/dsh-tool-fs'
+
+- id: tool-fs-search
+  name: '@deepseek-ai/dsh-tool-fs-search'
+  config:
+    sampleOverCapGlobResults: false
+
+# The Minimal preset's second tool: `str_replace_editor` over a bare local
+# filesystem, byte-identical in configuration to the official `minimal`
+# preset's `filesystem` group. The editor's own realm shadows the host's
+# sandboxed `fs` provider only inside this group, so the standard `read`/
+# `write`/`edit` tools keep the sandboxed fs while the bootstrap editor uses
+# the local one.
+- id: bootstrap-filesystem
+  name: cordis:group
+  group: true
+  isolate:
+    fs: true
+  config:
+    - id: fs-local
+      name: '@deepseek-ai/dsh-fs-local'
+      config:
+        cwd: !!js process.env.DSH_CWD ?? process.cwd()
+
+    - id: str-replace-editor
+      name: '@deepseek-ai/dsh-tool-str-replace-editor'
+      config:
+        maxOutputChars: 16000
+
+# ── background jobs ────────────────────────────────────────────────────────
+
+# Only the model-facing controls. The task REGISTRY stays on the host plane:
+# its producers sit outside any realm this file could put it in — `tool-bash`
+# above resolves it with `ctx.get`, and an entry-local realm here is invisible
+# to every sibling row, so `run_in_background` would answer "background jobs
+# unavailable" while these controls sat in the catalog. The registry is keyed by
+# owning agent anyway, so one host instance serves every session. What a preset
+# chooses is whether its agent can collect and stop background work at all.
+- id: tool-jobs
+  name: '@deepseek-ai/dsh-tool-jobs'
+
+# ── skills ──────────────────────────────────────────────────────────────────
+
+# The skill REGISTRY lives in the host composition and is layered per scope:
+# these rows register into THIS preset's layer of it, so they need no realm.
+# `skill-filesystem` contributes local-root discovery for agents on this
+# preset. The full skill CATALOG injection (`dsh-tool-skill`, the ~9KB
+# `<available_skills>` reminder) is REMOVED (local addition): it perturbs the
+# trajectory (issue #6: 0/9 anchored with the catalog present vs ~81%
+# without). Instead `skill-search` exposes two small on-demand tools —
+# skill_search (list matching summaries) and skill_load (inject one skill's
+# full instructions) — the tool-search pattern.
+- id: skill-filesystem
+  name: '@deepseek-ai/dsh-skill-filesystem'
+
+- id: skill-search
+  name: ./skill-search.mjs
+
+# ── goals ───────────────────────────────────────────────────────────────────
+
+# Only the model-facing tool. The goal SERVICE, its session driver, and the
+# `/goal` command stay on the host plane: the Gateway serves the goal domain as
+# Remote endpoints whose receiver comes from a generated descriptor, so it
+# resolves `goals` on the host and an entry-local realm here would hide it. The
+# registry is keyed by session anyway, so one host instance serves every
+# session. What a preset chooses is whether its agent can call the goal tool.
+- id: tool-goal
+  name: '@deepseek-ai/dsh-tool-goal'
+
+# ── plan mode ───────────────────────────────────────────────────────────────
+
+# Plan state is per-agent by nature, so an entry-local realm is not a
+# workaround here — it is the correct lifetime.
+- id: planning
+  name: cordis:group
+  group: true
+  isolate:
+    planMode: true
+  config:
+    - id: plan-mode
+      name: '@deepseek-ai/dsh-plan-mode'
+      config:
+        section: |
+              You are in plan mode. Stay in plan mode until exit_plan_mode succeeds or the user switches the session mode. Imperative language to implement changes means plan the implementation, not execute it. A user's conversational agreement — including an answer confirming something you asked — approves nothing and does not end plan mode; fold the confirmed decision into the plan and submit it through exit_plan_mode.
+
+              Explore first. Use non-mutating reads, searches, static analysis, and checks to ground the plan in the actual repository. Do not edit or write files, change configuration, run formatters or code generation that rewrites tracked files, commit, or otherwise carry out the plan. Prefer existing functions and patterns over new machinery.
+
+              The tool catalog stays the same across modes for request-cache stability. These plan-mode rules override any later tool description or guidance that suggests using mutation tools; those tools remain listed to keep the tool catalog unchanged. Do not use todo_write to track this planning phase: it tracks implementation after an approved plan, while the plan itself belongs in exit_plan_mode.
+
+              Resolve discoverable facts by inspection. Use ask_user_question only for user-owned choices or material ambiguity that inspection cannot answer. Do not ask the user where code lives or how current behavior works when you can find out.
+
+              Make the plan decision-complete: state the goal and success criteria; group implementation changes by subsystem; identify public API, schema, and data-flow changes; cover edge cases, failure modes, tests, acceptance criteria, and explicit assumptions. Keep it concise enough to review but detailed enough that another engineer can implement it without making design decisions.
+
+              When ready, call exit_plan_mode with the complete plan markdown, starting with a # title. Make exit_plan_mode the only and final tool call in that assistant response: it presents the plan for approval, and implementation begins only in a later step after approval. Do not paste the final plan as a plain reply or ask "should I proceed?" through prose or ask_user_question. If review rejects it, incorporate the feedback and present again. If the review channel is unavailable or aborted, stay in plan mode and ask the user to switch modes manually; do not proceed with implementation.
+
+# ── compaction ──────────────────────────────────────────────────────────────
+
+# `compaction-basic` reads `toolResultPrune` through `ctx.get`, so the pruner must
+# share this realm rather than sit outside it.
+#
+# `tokenMeter` is deliberately NOT in this realm: the meter stays on the HOST
+# plane, and the rows here resolve that one instance. It takes no configuration,
+# keys every fold by Session, and owns the context-meter projection units the
+# browser reads for every session — behind a realm those units would come and go
+# with whichever presets happen to be mounted. What a preset chooses is whether
+# its agent compacts at all, which is `compaction-basic` below.
+- id: compaction
+  name: cordis:group
+  group: true
+  isolate:
+    compaction: true
+    toolResultPruner: true
+  config:
+    - id: compaction-basic
+      name: '@deepseek-ai/dsh-compaction-basic'
+
+    - id: command-compact
+      name: '@deepseek-ai/dsh-command-compact'
+
+    - id: tool-result-pruner
+      name: '@deepseek-ai/dsh-compaction-tool-result-pruner'
+      config:
+        thresholdChars: 8192
+        headChars: 4096
+        tailChars: 1024
+
+# ── delegation and workflows ────────────────────────────────────────────────
+
+# The `subagents` registry and its spawn/fork backends live in the HOST
+# composition: the registry is a process singleton whose cross-session queries
+# the api-proxy serves to the browser, and a provider name may only be
+# registered once. This preset contributes the delegation TOOLS, which resolve
+# that host registry.
+#
+# `workflows` is different — nothing outside an agent reads it — so every row
+# that reaches it shares one entry-local realm here, and a consumer left
+# outside would resolve a host registry this preset does not populate.
+#
+# `tool-subagent-report` is host-plane for the same reason as the registry,
+# not because a preset may not want it: it registers a CONTINUABLE SETUP on
+# that singleton rather than a tool this agent calls, and the setup list is
+# not scope-aware — one copy per mounted preset means every child gets
+# `report` registered once per live session, which throws on the second.
+- id: delegation
+  name: cordis:group
+  group: true
+  isolate:
+    workflowEngine: true
+  config:
+    - id: tool-subagent-control
+      name: '@deepseek-ai/dsh-tool-subagent-control'
+
+    - id: tool-subagent-list-agents
+      name: '@deepseek-ai/dsh-tool-subagent-control/list-agents'
+
+    - id: tool-subagent
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: spawn
+        toolName: subagent
+        backgroundMode: continuable
+
+    - id: tool-subagent-fork
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: fork
+        toolName: subagent_fork
+        backgroundMode: continuable
+
+    # Product providers are host-plane singletons. Copy this preset, then
+    # remove `disabled` from either ordinary tool row to expose that product
+    # only to agents composed from the copy.
+    - id: tool-subagent-codex
+      name: '@deepseek-ai/dsh-tool-subagent'
+      disabled: true
+      config:
+        provider: codex
+        toolName: subagent_codex
+        enableRunInBackground: false
+        maxDepth: provider-managed
+
+    - id: tool-subagent-claude-code
+      name: '@deepseek-ai/dsh-tool-subagent'
+      disabled: true
+      config:
+        provider: claude-code
+        toolName: subagent_claude_code
+        enableRunInBackground: false
+        maxDepth: provider-managed
+
+    - id: workflow-worker-thread
+      name: '@deepseek-ai/dsh-workflow-worker-thread'
+      config:
+        provider: spawn
+
+    - id: tool-workflow
+      name: '@deepseek-ai/dsh-tool-workflow'
+
+    - id: tool-ralph
+      name: '@deepseek-ai/dsh-tool-ralph'
+      config:
+        subagentProvider: spawn
+        maxRounds: 64
+
+# ── remaining model-facing rows ─────────────────────────────────────────────
+
+- id: tool-ask-user
+  name: '@deepseek-ai/dsh-tool-ask-user'
+
+- id: tool-todo
+  name: '@deepseek-ai/dsh-tool-todo'
+  config:
+    allowParallelInProgress: true
+
+# The `web` service and its search provider stay in the host composition; only
+# the model-facing tool is per-session.
+- id: tool-web
+  name: '@deepseek-ai/dsh-tool-web'
+  config:
+    fetch: false
+    searchTimeoutMs: 60000

--- a/anchored-standard-dual-anchor/compaction-epoch.mjs
+++ b/anchored-standard-dual-anchor/compaction-epoch.mjs
@@ -1,0 +1,74 @@
+/**
+ * Epoch-aware promotion tracker shared by the bootstrap and baseline-gate
+ * plugins of the anchored presets.
+ *
+ * A compaction rewrites the model-visible surface: the pre-compaction
+ * conversation collapses into one synthetic summary message, and the
+ * workspace-instruction baseline is re-injected from scratch. The first
+ * post-compaction request is therefore a "second first request" — the same
+ * first-token conditions the anchored presets exist to control. Promotion is
+ * epoch-aware: only a durable promotion signal (`tool/call` and/or
+ * `assistant/message`, per the caller's `promoteEvents`) recorded AFTER the
+ * last `compaction/end` boundary counts as promoted. Before any compaction
+ * the boundary is -1, which preserves the original one-shot semantics.
+ *
+ * State is memoized per session id and maintained incrementally through
+ * `observe()`; a cold session scans its durable log once (so resume and
+ * reload reconstruct the same phase), then O(1).
+ */
+
+/** Build one epoch-aware promotion tracker. */
+export function createEpochPromotion(promoteEvents) {
+  const promote = new Set(promoteEvents)
+  /** sessionId -> { boundary, promoted } */
+  const state = new Map()
+
+  /** Scan a session's durable log from scratch (cold start / resume). */
+  const scan = (session) => {
+    let boundary = -1
+    let promoted = false
+    for (const event of session.events) {
+      const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
+      if (event.type === 'compaction/end') {
+        boundary = seq
+        promoted = false
+        continue
+      }
+      if (promote.has(event.type) && seq > boundary) promoted = true
+    }
+    const entry = { boundary, promoted }
+    state.set(session.id, entry)
+    return entry
+  }
+
+  return {
+    /**
+     * Current phase of the agent's session.
+     * @param agent - the assembly/pre-step agent, or undefined outside an agent.
+     * @returns { boundary, promoted } — `boundary` is the last compaction/end
+     *   seq (-1 before any compaction); `promoted` is true when a durable
+     *   promotion signal exists after that boundary.
+     */
+    status(agent) {
+      if (agent === undefined) return { boundary: -1, promoted: true }
+      const session = agent.session
+      if (session === undefined) return { boundary: -1, promoted: true }
+      // Subagents keep the full catalog from their very first request.
+      if ((session.header?.delegationDepth ?? 0) > 0) return { boundary: -1, promoted: true }
+      return state.get(session.id) ?? scan(session)
+    },
+    /** Incremental feed: call on every `session/event`. */
+    observe(session, event) {
+      const entry = state.get(session.id)
+      if (entry === undefined) return
+      const seq = event.seq ?? 0
+      if (event.type === 'compaction/end') {
+        state.set(session.id, { boundary: seq, promoted: false })
+        return
+      }
+      if (promote.has(event.type) && seq > entry.boundary && !entry.promoted) {
+        state.set(session.id, { ...entry, promoted: true })
+      }
+    },
+  }
+}

--- a/anchored-standard-dual-anchor/custom-bash.mjs
+++ b/anchored-standard-dual-anchor/custom-bash.mjs
@@ -1,0 +1,126 @@
+/**
+ * custom-bash — a Windows-capable `bash` tool that registers under the SAME
+ * name (`bash`) as the official persistent bash, with a Minimal-compatible
+ * description, but executes through `ctx.subprocess.spawn` instead of a PTY.
+ *
+ * WHY: DeepSeek's first-request trajectory anchor keys on the tool SCHEMA
+ * matching the RL training distribution (issue #11: persistent
+ * bash + str_replace_editor anchored 5/5 at maxTokens=256000, pwsh/read
+ * 8/8 standard-like). The official persistent bash uses a PTY, and DSH's PTY
+ * backend is linux/darwin-only — `subprocess-local` throws "terminal
+ * inspection is unsupported on platform win32". A custom tool that presents
+ * the same name and a Minimal-like description but spawns Git Bash through
+ * the ordinary (cross-platform) subprocess seam keeps the schema anchor
+ * without the PTY dependency.
+ *
+ * Executable resolution (config `bashPath`):
+ *  - explicit absolute path (e.g. `C:\Program Files\Git\bin\bash.exe`), or
+ *  - `bash` resolved through `ctx.subprocess.resolveExecutable` (PATH lookup).
+ *
+ * Semantics mirror the official bash tool: `bash -c <command>` in a fresh
+ * process, bounded output, non-zero exit reported not thrown. No sandbox
+ * confinement on Windows (the sandbox backend is linux-only); the tool
+ * description says so. The bootstrap catalog pairs this with
+ * `str_replace_editor` (Minimal's two tools).
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'custom-bash'
+
+/** The subprocess and tools services must exist before this tool can register. */
+export const inject = ['subprocess', 'tools']
+
+const DEFAULT_TIMEOUT_MS = 120000
+const DEFAULT_MAX_OUTPUT_BYTES = 64000
+
+/** Tool parameter schema for the model-facing command. */
+const commandSchema = {
+  type: 'object',
+  properties: {
+    command: {
+      type: 'string',
+      description: 'The bash command to execute (`bash -c` string domain).',
+    },
+    workdir: {
+      type: 'string',
+      description: 'Optional working directory; defaults to the session cwd.',
+    },
+  },
+  required: ['command'],
+  additionalProperties: false,
+}
+
+/** Register the model-facing `bash` tool. */
+export function apply(ctx, config) {
+  const bashPath = typeof config?.bashPath === 'string' && config.bashPath.length > 0 ? config.bashPath : 'bash'
+  const timeoutMs = Number.isSafeInteger(config?.timeoutMs) && config.timeoutMs > 0 ? config.timeoutMs : DEFAULT_TIMEOUT_MS
+  const maxOutputBytes = Number.isSafeInteger(config?.maxOutputBytes) && config.maxOutputBytes > 0 ? config.maxOutputBytes : DEFAULT_MAX_OUTPUT_BYTES
+
+  ctx.tools.register({
+    name: 'bash',
+    description: [
+      'Run commands in a bash shell (Git Bash on Windows)',
+      '* When invoking this tool, the contents of the "command" parameter does NOT need to be XML-escaped.',
+      "* You don't have access to the internet via this tool.",
+      '* You do have access to a mirror of common linux and python packages via apt and pip.',
+      '* State does NOT persist across command calls: each call runs in a fresh shell.',
+      "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
+      '* Please avoid commands that may produce a very large amount of output.',
+      '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+    ].join('\n'),
+    parameters: commandSchema,
+    output: {
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          text: { type: 'string' },
+        },
+        required: ['text'],
+      },
+      render: (_args, value) => [{ type: 'text', text: value.text }],
+    },
+    async execute(args, exec) {
+      const shell = await ctx.subprocess.resolveExecutable(bashPath, undefined, exec?.signal)
+      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+        ? args.workdir
+        : exec?.agent?.session?.header?.cwd
+      const signal = exec?.signal
+      const handle = ctx.subprocess.spawn({
+        argv: [shell, '-c', args.command],
+        ...workdir !== undefined ? { cwd: workdir } : {},
+        stdio: {
+          stdin: 'ignore',
+          stdout: { maxBytes: maxOutputBytes },
+          stderr: { maxBytes: maxOutputBytes },
+        },
+        ...signal !== undefined ? { signal } : {},
+        graceMs: 3000,
+      })
+      let outcome
+      try {
+        outcome = await handle.done
+      } catch (error) {
+        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+        // which the runtime turns into an isError result.
+        throw new Error(`bash spawn failed: ${String(error)}`)
+      }
+      let stdout = ''
+      let stderr = ''
+      try {
+        stdout = handle.collected.stdout.readFrom(0).text
+        stderr = handle.collected.stderr.readFrom(0).text
+      } catch {
+        // Collected readers may be unavailable on some backends; tolerate.
+      }
+      const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
+      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      if (outcome.exitCode !== 0) {
+        // Non-zero exit is a reported failure, not a throw: the model sees the
+        // command output plus the exit code.
+        throw new Error(tail)
+      }
+      return { text: tail }
+    },
+  })
+}

--- a/anchored-standard-dual-anchor/dev-tool-search.mjs
+++ b/anchored-standard-dual-anchor/dev-tool-search.mjs
@@ -1,0 +1,129 @@
+/**
+ * dev-tool-search — on-demand tool discovery and unlock, the tool-search
+ * pattern for the anchored preset.
+ *
+ * The promoted phase keeps only a minimal resident set (shell +
+ * str_replace_editor + the discovery tools) instead of dumping the whole
+ * Standard catalog at once. This plugin registers ONE small tool:
+ *
+ *  - `dev_tool_search` — search the FULL assembled catalog by keyword and
+ *    return matching tool names with short descriptions; optionally unlock
+ *    tools by exact name (array `toolNames`). Unlocked names are recorded as
+ *    durable `tool/call` arguments, and tool-bootstrap.mjs's assemble filter
+ *    exposes them from the next request on (resume-safe).
+ *
+ * The tool description is deliberately an INDEX of what the minimal resident
+ * set cannot do: the model should reach for dev_tool_search the moment a task
+ * needs internet, delegation, workflows, goals, images, background jobs, or
+ * multi-agent coordination — not try to work around them with bash.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'dev-tool-search'
+
+/** The tools registry must exist before this tool can register. */
+export const inject = ['tools']
+
+const MAX_RESULTS = 25
+
+/** Minimal JSON schema compiler for tool parameters (zero dependencies). */
+function toJsonSchema(spec) {
+  const properties = {}
+  const required = []
+  for (const [key, meta] of Object.entries(spec || {})) {
+    const prop = { type: meta.type }
+    if (meta.description) prop.description = meta.description
+    properties[key] = prop
+    if (meta.required) required.push(key)
+  }
+  return { type: 'object', properties, required, additionalProperties: false }
+}
+
+/**
+ * The capability index: resident minimal tools (bash / str_replace_editor /
+ * skill_search / skill_load) cannot cover these, so the model must search
+ * and unlock them on demand. Kept in the description so the model KNOWS what
+ * exists without a full catalog dump.
+ */
+const UNLOCKABLE_INDEX = [
+  'web_search — internet search and web retrieval',
+  'subagent / subagent_fork — delegate work to sub-agents',
+  'workflow — run multi-agent workflow scripts',
+  'ralph — fresh-agent iterative loop',
+  'create_goal / get_goal / update_goal — long-running goals',
+  'read_image — read image files',
+  'job_list / job_output / job_kill — background jobs',
+  'interrupt_agent / send_message / list_agents — multi-agent control',
+  'todo_write — task tracking',
+  'ask_user_question — ask the user',
+]
+
+/** Register the model-facing `dev_tool_search` tool. */
+export function apply(ctx) {
+  ctx.tools.register({
+    name: 'dev_tool_search',
+    description: [
+      'Discover and unlock tools that are NOT currently available.',
+      '',
+      'This session starts with a minimal resident set: bash, str_replace_editor, skill_search, skill_load. Everything else is unlocked on demand through this tool.',
+      '',
+      'If the current task needs any of the following, call dev_tool_search FIRST — do not try to work around them with bash:',
+      ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
+      '',
+      'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+    ].join('\n'),
+    parameters: toJsonSchema({
+      query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
+      toolNames: { type: 'array', required: false, description: 'exact tool names to unlock', items: { type: 'string' } },
+    }),
+    output: {
+      schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
+      render: (_a, v) => [{ type: 'text', text: v.text }],
+    },
+    async execute(args, exec) {
+      const query = typeof args.query === 'string' ? args.query.trim() : ''
+      const unlock = Array.isArray(args.toolNames) ? args.toolNames.filter((name) => typeof name === 'string' && name.length > 0) : []
+
+      const lines = []
+      if (unlock.length > 0) {
+        lines.push(`Unlocked for the next request: ${unlock.join(', ')}`)
+      }
+      if (query.length === 0 && unlock.length === 0) {
+        lines.push('Provide `query` to search the catalog, or `toolNames` to unlock tools.')
+        return { text: lines.join('\n') }
+      }
+      if (query.length === 0) {
+        return { text: lines.join('\n') || 'Nothing to do.' }
+      }
+
+      try {
+        // The executing agent IS the viewing scope: preset tools register into
+        // the agent-scope layer of the tools registry, and schemas() with no
+        // scope only sees the global layer — every preset-provided tool would
+        // be invisible to keyword search (issue #24). Same pattern as the
+        // harness's own code mode (`registry.schemas(exec.agent)`).
+        const schemas = ctx.tools.schemas(exec?.agent)
+        const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
+        const matches = schemas
+          .filter((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            return wanted.every((token) => haystack.includes(token))
+          })
+          .slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(`No tools match "${query}".`)
+        } else {
+          lines.push(`Matching tools (${matches.length}):`)
+          for (const schema of matches) {
+            const desc = (schema.description || '').split('\n')[0].slice(0, 90)
+            lines.push(`- ${schema.name}: ${desc}`)
+          }
+          lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')
+        }
+      } catch (error) {
+        lines.push(`catalog search unavailable: ${String((error && error.message) || error)}`)
+      }
+      return { text: lines.join('\n') }
+    },
+  })
+}

--- a/anchored-standard-dual-anchor/instruction-hint.mjs
+++ b/anchored-standard-dual-anchor/instruction-hint.mjs
@@ -1,0 +1,178 @@
+/**
+ * instruction-hint — replace `dsh-agent-instructions`' full AGENTS.md/CLAUDE.md
+ * injection with a minimal "these files exist" hint.
+ *
+ * WHY: the full workspace-instruction digest is a large injected block. After
+ * the anchored bootstrap promotes, we want the model to KNOW the instruction
+ * files exist (so it reads them before acting) without dumping their content
+ * into every request. The model reads the files itself via the filesystem
+ * tools when it needs them.
+ *
+ * Behavior:
+ *  - After the session records its first durable promotion signal
+ *    (`promoteOn`, default `either`), ONE hint message is injected (once per
+ *    session — durable event scan, resume-safe), listing which instruction
+ *    files were found:
+ *      - user-global: `$DSH_HOME/AGENTS.md`
+ *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
+ *        walking up from the session cwd to the project root (a directory
+ *        containing `.git`, or the cwd itself).
+ *  - The hint instructs the model to READ the files before acting when
+ *    relevant, without embedding their content.
+ *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
+ *    service or an unreadable probe degrades to no hint (never throws).
+ *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
+ *
+ * ROW ORDER: this plugin registers its `agent/pre-step` handler with
+ * `prepend: true` and after `tool-bootstrap`, so it runs inside the
+ * bootstrap's outermost strip — but it emits AFTER promotion, when the strip
+ * is inactive. The hint source kind is `instruction-hint`, which is NOT in
+ * `suppressedContextSources`, so it is never stripped.
+ */
+
+import { createEpochPromotion } from './compaction-epoch.mjs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'instruction-hint'
+
+/** Durable session event types that count as a promotion signal per mode. */
+const PROMOTE_EVENTS = {
+  'tool-call': ['tool/call'],
+  'assistant-message': ['assistant/message'],
+  either: ['tool/call', 'assistant/message'],
+}
+
+/** Candidate file names, in probe order, for the project chain and user-global. */
+const PROJECT_CANDIDATES = ['AGENTS.md', 'CLAUDE.md', 'AGENTS.local.md', 'CLAUDE.local.md']
+const USER_GLOBAL_CANDIDATE = 'AGENTS.md'
+
+function parsePromoteOn(value) {
+  if (value === undefined || value === 'either') return PROMOTE_EVENTS.either
+  if (value === 'tool-call' || value === 'assistant-message') return PROMOTE_EVENTS[value]
+  throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
+}
+
+/** Find the project root: first ancestor containing any root marker (e.g. .git). */
+async function findProjectRoot(fs, cwd, signal) {
+  let current = cwd
+  for (;;) {
+    for (const marker of ['.git', '.hg', '.svn']) {
+      try {
+        const target = await fs.resolve(joinPath(current, marker), { cwd, signal })
+        const info = await fs.stat(target, signal)
+        if (info !== undefined) return current
+      } catch {
+        // Probe failure = marker absent; continue.
+      }
+    }
+    const parent = parentPath(current)
+    if (parent === current || parent.length === 0) return cwd
+    current = parent
+  }
+}
+
+/** List instruction files present in one directory (project candidates). */
+async function presentInDir(fs, dir, candidates, signal) {
+  const found = []
+  for (const candidate of candidates) {
+    try {
+      const target = await fs.resolve(joinPath(dir, candidate), { cwd: dir, signal })
+      const info = await fs.stat(target, signal)
+      if (info !== undefined && info.type === 'file') found.push(candidate)
+    } catch {
+      // Absent or unreadable — skip.
+    }
+  }
+  return found
+}
+
+/** Join one path segment onto a directory (platform-agnostic string join). */
+function joinPath(dir, segment) {
+  if (dir.endsWith('/') || dir.endsWith('\\')) return dir + segment
+  const sep = dir.includes('\\') ? '\\' : '/'
+  return dir + sep + segment
+}
+
+/** Parent of an absolute Windows or POSIX path. */
+function parentPath(path) {
+  const idx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'))
+  if (idx <= 0) return path
+  const parent = path.slice(0, idx)
+  return parent.length === 0 ? path : parent
+}
+
+/** Register the post-promotion instruction-hint injector. */
+export function apply(ctx, config) {
+  const promoteEvents = parsePromoteOn(config.promoteOn)
+  const promotion = createEpochPromotion(promoteEvents)
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
+  /** Sessions that already received the hint. */
+  const hinted = new Set()
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  ctx.on('agent/pre-step', async ({ agent, signal }, next) => {
+    const decision = await next()
+    try {
+      if (promotion.status(agent).promoted !== true) return decision
+      const session = agent.session
+      if (session === undefined || hinted.has(session.id)) return decision
+      hinted.add(session.id)
+
+      const fs = ctx.get('fs')
+      if (fs === undefined) return decision
+      const cwd = session.header.cwd ?? process.cwd()
+
+      const projectFiles = []
+      const root = await findProjectRoot(fs, cwd, signal)
+      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+
+      const userGlobalFiles = []
+      try {
+        const dshHome = process.env.DSH_HOME ?? (process.env.USERPROFILE ? `${process.env.USERPROFILE}\\.dsh` : undefined)
+        if (dshHome !== undefined) {
+          userGlobalFiles.push(...await presentInDir(fs, dshHome, [USER_GLOBAL_CANDIDATE], signal))
+        }
+      } catch {
+        // Unreadable home probe — ignore.
+      }
+
+      const sections = []
+      if (projectFiles.length > 0) {
+        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+      }
+      if (userGlobalFiles.length > 0) {
+        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+      }
+      if (sections.length === 0) return decision
+
+      const text = [
+        ...sections,
+        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+      ].join(' ')
+
+      return {
+        ...decision,
+        messages: [...decision.messages, {
+          id: `instruction-hint-${session.id}`,
+          role: 'user',
+          content: [{ type: 'text', text }],
+          source: { kind: 'instruction-hint', form: 'hint' },
+        }],
+      }
+    } catch (error) {
+      // A hint bug must never hurt the session: skip the hint.
+      warnOnce(`${name}: hint injection failed, skipping: ${String((error && error.message) || error)}`)
+      return decision
+    }
+  }, { prepend: true })
+}

--- a/anchored-standard-dual-anchor/preset.yml
+++ b/anchored-standard-dual-anchor/preset.yml
@@ -1,0 +1,3 @@
+name: Anchored Standard (dual-anchor, experimental)
+description: Bootstrap with the Minimal preset's real tool pair (persistent bash + str_replace_editor) AND a 1024-token output cap, with no auto-injected workspace or skill context — running BOTH the schema anchor (path A) and the cap anchor (path B, issue #11) in parallel for stability — then expose the full Standard catalog after the first durable tool call or reply.
+order: 5

--- a/anchored-standard-dual-anchor/skill-search.mjs
+++ b/anchored-standard-dual-anchor/skill-search.mjs
@@ -1,0 +1,142 @@
+/**
+ * skill-search — on-demand skill discovery and loading, replacing
+ * `dsh-tool-skill`'s full-catalog injection.
+ *
+ * WHY: the available-skills reminder (`<available_skills>`, ~9KB with many
+ * skills) is injected into the first step by dsh-tool-skill and again after
+ * every promotion/compaction. That large injected block perturbs the
+ * trajectory (issue #6: 0/9 anchored with the catalog present vs ~81%
+ * without). We remove the catalog injection entirely and expose two small
+ * tools instead — the Claude tool-search pattern:
+ *
+ *  - `skill_search` — list skills whose name/description match a query
+ *    (summaries only, bounded; no bodies). The model discovers what exists
+ *    without a 9KB dump.
+ *  - `skill_load` — load ONE skill's full instructions by exact name and
+ *    inject them for the NEXT request via `agent.inject` (the non-waking
+ *    next-step inbox). The model (or the user) calls this only when the
+ *    skill is actually needed.
+ *
+ * Discovery reads `ctx.skills` scoped to the calling agent, exactly like
+ * dsh-tool-skill. If skills are unavailable the tools answer with a short
+ * message instead of throwing.
+ *
+ * NOTE: this plugin REPLACES the `dsh-tool-skill` row in the composition —
+ * the composition must NOT mount both, or the catalog injection returns.
+ */
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'skill-search'
+
+/** The agent, tools, and skills services must exist before these tools can register. */
+export const inject = ['agents', 'tools', 'skills']
+
+const MAX_RESULTS = 20
+
+/** Minimal JSON schema compiler for tool parameters (zero dependencies). */
+function toJsonSchema(spec) {
+  const properties = {}
+  const required = []
+  for (const [key, meta] of Object.entries(spec || {})) {
+    const prop = { type: meta.type }
+    if (meta.description) prop.description = meta.description
+    properties[key] = prop
+    if (meta.required) required.push(key)
+  }
+  return { type: 'object', properties, required, additionalProperties: false }
+}
+
+/** Register the two on-demand skill tools. */
+export function apply(ctx) {
+  /** Normalize a query into lowercase tokens for simple substring matching. */
+  const tokens = (text) => (text || '').toLowerCase().split(/[^a-z0-9_-]+/).filter(Boolean)
+
+  ctx.tools.register({
+    name: 'skill_search',
+    description: 'Search the available skills by keyword and return matching skill names with short descriptions. This session keeps NO skill catalog in the prompt — if a task looks like it matches a skill (document conversion, image processing, game reviews, markdown, PDF, spreadsheets, …), call skill_search FIRST to find it, then skill_load to activate it. Do NOT assume skill names from memory.',
+    parameters: toJsonSchema({
+      query: { type: 'string', required: true, description: 'search keywords (e.g. "pdf", "obsidian", "game review")' },
+    }),
+    output: {
+      schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
+      render: (_a, v) => [{ type: 'text', text: v.text }],
+    },
+    async execute(args, exec) {
+      const wanted = tokens(args.query)
+      const scope = exec?.agent ?? ctx
+      try {
+        const all = await ctx.skills.list({
+          scope,
+          cwd: exec?.agent?.session?.header?.cwd,
+          signal: exec?.signal,
+        })
+        const matches = all.filter((skill) => {
+          if (wanted.length === 0) return true
+          const haystack = tokens(`${skill.name} ${skill.description ?? ''} ${skill.whenToUse ?? ''}`).join(' ')
+          return wanted.every((token) => haystack.includes(token))
+        })
+        const head = matches.slice(0, MAX_RESULTS)
+        const lines = head.map((skill) => {
+          const desc = (skill.description || '').split('\n')[0]
+          return `- ${skill.name}: ${desc}`
+        })
+        if (lines.length === 0) return { text: `No skills match "${args.query}". Use skill_search with other keywords.` }
+        const extra = matches.length > MAX_RESULTS ? `\n…(${matches.length - MAX_RESULTS} more)` : ''
+        return { text: `Matching skills (${matches.length}):\n${lines.join('\n')}${extra}\n\nLoad one with skill_load (exact name).` }
+      } catch (error) {
+        return { text: `skill_search unavailable: ${String((error && error.message) || error)}` }
+      }
+    },
+  })
+
+  ctx.tools.register({
+    name: 'skill_load',
+    description: 'Load the full instructions of ONE skill by its exact name (from skill_search results) and inject them for the next request. Call this before acting on a task that matches the skill.',
+    parameters: toJsonSchema({
+      name: { type: 'string', required: true, description: 'exact skill name (kebab-case, from skill_search)' },
+    }),
+    output: {
+      schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string' } }, required: ['text'] },
+      render: (_a, v) => [{ type: 'text', text: v.text }],
+    },
+    async execute(args, exec) {
+      try {
+        const agent = exec?.agent
+        if (agent === undefined) return { text: 'skill_load requires an agent context.' }
+        const skill = await ctx.skills.get(args.name, {
+          scope: agent,
+          cwd: agent.session.header.cwd,
+          signal: exec?.signal,
+        })
+        if (skill === undefined) {
+          return { text: `No skill named "${args.name}". Run skill_search to list available skills.` }
+        }
+        const body = extractSkillBody(skill)
+        if (body.length === 0) {
+          return { text: `Skill "${args.name}" has no loadable body.` }
+        }
+        // Queue the skill content as a non-waking next-step context message,
+        // exactly like dsh-tool-skill's invocation injection.
+        agent.inject({
+          id: `skill-load-${args.name}-${Date.now()}`,
+          role: 'user',
+          content: [{ type: 'text', text: body }],
+          source: { kind: 'skill-invocation', name: args.name, form: 'instructions' },
+        })
+        return { text: `Skill "${args.name}" loaded; its instructions will be injected for the next request.` }
+      } catch (error) {
+        return { text: `skill_load failed: ${String((error && error.message) || error)}` }
+      }
+    },
+  })
+}
+
+/** Extract the model-facing body of a loaded skill definition. */
+function extractSkillBody(skill) {
+  const content = skill?.content ?? skill?.instructions ?? skill?.body
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content.map((part) => (typeof part === 'string' ? part : JSON.stringify(part))).join('\n')
+  }
+  return ''
+}

--- a/anchored-standard-dual-anchor/tool-bootstrap.mjs
+++ b/anchored-standard-dual-anchor/tool-bootstrap.mjs
@@ -1,0 +1,338 @@
+/**
+ * Anchored tool bootstrap — keep the FIRST model request on the Minimal
+ * preset's REAL tool schema (persistent `bash` + `str_replace_editor`), free
+ * of auto-injected workspace/skill context, then narrow the catalog to a
+ * minimal RESIDENT set once the session has produced its first durable
+ * promotion signal.
+ *
+ * The phase is derived from durable session events, so resume and reload
+ * preserve it. By default (`promoteOn: 'either'`) a session promotes after the
+ * first `tool/call` OR the first `assistant/message`, whichever comes first:
+ * request #1 always sees the bootstrap catalog and request #2 always sees the
+ * resident catalog. The original `'tool-call'` mode is kept for compatibility,
+ * but it can trap a session in bootstrap forever when the first model reply
+ * makes no tool call — the `'either'` default removes that trap while keeping
+ * the first-request anchor intact.
+ *
+ * First-request conditions established by the reproduction work (issues #6
+ * and #11, 2026-08-15):
+ *
+ *  1. Tool schema. The API-visible first-request catalog decides whether the
+ *     session anchors on the Minimal trajectory. At the adapter-default
+ *     maxTokens (256000 on the official endpoint) the Minimal tool pair —
+ *     persistent `bash` + `str_replace_editor` — anchored 5/5 runs with zero
+ *     `let me` first-lines, while every standard-family schema (pwsh/read,
+ *     pwsh only, sandboxed bash/read) fell into standard-like behavior
+ *     (11/11). Bootstrap therefore exposes exactly the Minimal pair, not
+ *     Standard's `pwsh`/`read`.
+ *
+ *  2. Output budget. On the official endpoint the first request's `max_tokens`
+ *     also dominated the trajectory anchor at 1024 (`We need` style in 26/32
+ *     runs against 0/5 at 256000, independent of tool descriptions). The
+ *     Minimal tool schema, however, anchors at 256000 WITHOUT any cap, and the
+ *     cap's delivery depends on the profile package's `prepareCall` behavior
+ *     (it reaches the request on the 0.1.0-rc.5 source checkout; a prebuilt
+ *     rc.6-reporting profile package observed in issue #11 overwrote it with
+ *     `adapterDefaults.maxTokens`). `bootstrapMaxTokens` is therefore OPT-IN:
+ *     leave it unset to run the Minimal schema at the adapter default, or set
+ *     it to cap the first request. When set, the cap is stripped after
+ *     promotion — the next request's seed proposal carries the previous
+ *     header's maxTokens forward, so the release must be explicit.
+ *
+ *  3. Injected reminders. dsh-agent-instructions and dsh-tool-skill inject
+ *     workspace instructions (AGENTS.md) and the skill catalog into the first
+ *     step as user messages whenever such content exists. With the skill
+ *     catalog present the anchor did not reproduce at all (0/9); without it
+ *     the same request reproduces at ~81%. Both message kinds are therefore
+ *     stripped during bootstrap and allowed again after promotion. The
+ *     stripped set is configurable via `suppressedContextSources` (default
+ *     `['skill-catalog', 'agent-instructions']`); an explicitly empty array
+ *     disables the context filter while keeping the tool bootstrap. A
+ *     user-initiated skill gesture (`skill-invocation`) is NOT in the default
+ *     set: it is not an automatic injection, and stripping it would lose the
+ *     skill content once the gesture scrolls out of the per-step claim.
+ *
+ * POST-PROMOTION RESIDENT SET (local addition, user-measured): the promoted
+ * phase does NOT dump the whole Standard catalog at once — that dump pulls
+ * the trajectory back to standard-like behavior (the root cause of the
+ * post-promotion regression measured on the zero variant). Instead the
+ * catalog narrows to the bootstrap tool pair PLUS the three discovery tools
+ * (`dev_tool_search`, `skill_search`, `skill_load`) plus whatever the model
+ * explicitly unlocked via `dev_tool_search`. Heavier Standard tools
+ * (web_search, subagent, workflow, …) are one `dev_tool_search` call away;
+ * unlocked names are derived from durable `tool/call` events, so resume and
+ * reload keep them. read/write/edit/glob/grep/todo/ask are deliberately NOT
+ * resident: bash + str_replace_editor cover file work.
+ *
+ * COMPACTION (local addition): a compaction rewrites the whole surface, so the
+ * first post-compaction request is a "second first request". Promotion is
+ * epoch-aware (see compaction-epoch.mjs): after `compaction/end` the session
+ * falls back to the controlled phase — the bootstrap pair plus
+ * `compactionTools` (a core work set, default none) — until a NEW durable
+ * promotion signal exists past that boundary. The model is mid-task and needs
+ * to keep working, but still faces a small catalog instead of the full
+ * Standard set.
+ *
+ * Robustness:
+ *  - Promotion decisions are memoized per session id for this process; the
+ *    durable event scan runs once per session per process, then O(1).
+ *  - Subagents (delegationDepth > 0) are always promoted (resident catalog).
+ *  - A missing bootstrap tool degrades to the full catalog with a one-time
+ *    warning instead of throwing, so a composition drift can never brick
+ *    every request of a session.
+ *  - The pre-step context filter degrades to "keep everything" on failure:
+ *    a filter bug must never eat the user's context.
+ *  - Invalid config (bad tool lists, unknown `promoteOn`, malformed
+ *    `suppressedContextSources`, non-positive `bootstrapMaxTokens`) fails at
+ *    apply time, i.e. at preset mount, where it is visible and fixable.
+ */
+
+import { createEpochPromotion } from './compaction-epoch.mjs'
+
+/** Cordis plugin name used by loader diagnostics. */
+export const name = 'anchored-tool-bootstrap'
+
+/**
+ * Deliberately NO inject list: the listeners only touch services at event
+ * time. Applying without an inject — combined with this row being FIRST in
+ * agent.cordis.yml — registers the plugin before dsh-agent-instructions and
+ * dsh-tool-skill, and waterfall after-next transforms apply in reverse
+ * registration order, so the first-request strip below is the LAST transform.
+ * With an inject here those plugins register first and re-inject their
+ * messages after the strip. The pre-step listener additionally registers with
+ * `prepend: true` so the strip stays the outermost transform even against
+ * host-plane listeners and future row reordering.
+ */
+export const inject = []
+
+/** Durable session event types that count as a promotion signal per mode. */
+const PROMOTE_EVENTS = {
+  'tool-call': ['tool/call'],
+  'assistant-message': ['assistant/message'],
+  either: ['tool/call', 'assistant/message'],
+}
+
+/** Every config key this plugin accepts — anything else is a typo. */
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools'])
+
+/**
+ * Context sources stripped from the first request by default. Both are
+ * automatic `agent/pre-step` injections: the available-skills reminder
+ * (`skill-catalog`) and the AGENTS.md/CLAUDE.md workspace digest
+ * (`agent-instructions`). True Minimal mounts neither plugin.
+ */
+const DEFAULT_SUPPRESSED_SOURCES = ['skill-catalog', 'agent-instructions']
+
+/**
+ * The default first-request catalog: the OFFICIAL Minimal preset's exact tool
+ * pair — the persistent `bash` shell and `str_replace_editor`. Issue #11
+ * measured this schema anchoring 5/5 at the adapter-default maxTokens while
+ * every standard-family schema failed 11/11.
+ */
+const DEFAULT_BOOTSTRAP_TOOLS = ['bash', 'str_replace_editor']
+
+/** Discovery tools always resident after promotion (the tool-search pattern). */
+const RESIDENT_DISCOVERY_TOOLS = ['dev_tool_search', 'skill_search', 'skill_load']
+
+function stringList(value, field) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be a non-empty array of non-empty strings`)
+  }
+  return [...new Set(value)]
+}
+
+function stringListOrEmpty(value, field) {
+  if (value === undefined) return []
+  return stringList(value, field)
+}
+
+function parsePromoteOn(value) {
+  if (value === undefined || value === 'either') return PROMOTE_EVENTS.either
+  if (value === 'tool-call' || value === 'assistant-message') return PROMOTE_EVENTS[value]
+  throw new TypeError(`${name}: promoteOn must be one of "tool-call", "assistant-message", "either"; got ${JSON.stringify(value)}`)
+}
+
+/**
+ * Validate the suppressed context sources. Unlike the bootstrap tool lists,
+ * an explicitly empty array is meaningful: it disables the context filter
+ * while keeping the tool bootstrap.
+ */
+function sourceList(value, field, fallback) {
+  if (value === undefined) return new Set(fallback)
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new TypeError(`${name}: ${field} must be an array of non-empty strings`)
+  }
+  return new Set(value)
+}
+
+/**
+ * Validate the optional first-request output cap. `undefined` means NO cap:
+ * the Minimal tool schema anchors at the adapter-default maxTokens, and the
+ * cap's delivery is profile-package dependent (see the header note), so it is
+ * opt-in rather than the default.
+ */
+function optionalPositiveInt(value, field) {
+  if (value === undefined) return undefined
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${name}: ${field} must be a positive safe integer`)
+  }
+  return value
+}
+
+/** Register the per-session bootstrap filters. */
+export function apply(ctx, config) {
+  const source = config === undefined ? {} : config
+  if (typeof source !== 'object' || source === null || Array.isArray(source)) {
+    throw new TypeError(`${name}: config must be an object`)
+  }
+  const unknown = Object.keys(source).filter((key) => !ALLOWED_KEYS.has(key))
+  if (unknown.length > 0) {
+    throw new TypeError(
+      `${name}: unknown config key(s) ${unknown.join(', ')} — allowed keys: ${[...ALLOWED_KEYS].sort().join(', ')}`,
+    )
+  }
+  const bootstrapTools = stringList(source.bootstrapTools, 'bootstrapTools')
+  const promoteEvents = parsePromoteOn(source.promoteOn)
+  const bootstrapMaxTokens = optionalPositiveInt(source.bootstrapMaxTokens, 'bootstrapMaxTokens')
+  const suppressedSources = sourceList(source.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
+  // Core work set exposed after a compaction, before re-promotion. Empty
+  // means "no compaction recovery catalog": the session stays on the
+  // bootstrap pair until a new promotion signal.
+  const compactionTools = stringListOrEmpty(source.compactionTools, 'compactionTools')
+
+  const promotion = createEpochPromotion(promoteEvents)
+  ctx.on('session/event', (session, event) => promotion.observe(session, event))
+
+  let warned = false
+  const warnOnce = (message) => {
+    if (warned) return
+    warned = true
+    try {
+      ctx.logger.warn(message)
+    } catch {
+      // Logger unavailable — the guard exists only to avoid spamming.
+    }
+  }
+
+  /**
+   * Tool names the model explicitly unlocked via `dev_tool_search` for one
+   * session. Derived from durable `tool/call` events so resume/reload keeps
+   * them. The event's `arguments` is the raw JSON string the model produced;
+   * we parse it defensively and read the `toolNames` array.
+   */
+  const unlockedFor = (session) => {
+    const unlocked = new Set()
+    if (session === undefined || !Array.isArray(session.events)) return unlocked
+    for (const event of session.events) {
+      if (event.type !== 'tool/call') continue
+      if (event.data?.name !== 'dev_tool_search') continue
+      let args
+      try {
+        args = JSON.parse(event.data.arguments)
+      } catch {
+        continue
+      }
+      if (args === null || typeof args !== 'object' || Array.isArray(args)) continue
+      const names = args.toolNames
+      if (Array.isArray(names)) for (const name of names) if (typeof name === 'string' && name.length > 0) unlocked.add(name)
+    }
+    return unlocked
+  }
+
+  /** Narrow the assembled catalog to a keep-set; validate required names. */
+  const keepTools = (assembled, keep, missingAllowsFullCatalog) => {
+    const available = new Set(assembled.tools.map((tool) => tool.name))
+    const missing = [...keep].filter((toolName) => !available.has(toolName))
+    if (missing.length > 0) {
+      warnOnce(
+        `${name}: expected every phase tool; missing=${JSON.stringify(missing)} — `
+        + (missingAllowsFullCatalog ? 'bootstrap disabled, full catalog exposed' : 'continuing with what is available'),
+      )
+      if (missingAllowsFullCatalog) return assembled
+    }
+    return {
+      ...assembled,
+      tools: assembled.tools.filter((tool) => keep.has(tool.name)),
+    }
+  }
+
+  ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is guarded.
+    const assembled = await next()
+    try {
+      const status = promotion.status(context.agent)
+      if (status.promoted) {
+        // PROMOTED: keep the minimal resident set — the bootstrap pair + the
+        // discovery tools + whatever the model explicitly unlocked via
+        // dev_tool_search — instead of dumping the whole Standard catalog at
+        // once (the post-promotion regression fix; see the header note).
+        const keep = new Set([...bootstrapTools, ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session)])
+        return keepTools(assembled, keep, false)
+      }
+      // Controlled phase: the bootstrap pair; after a compaction, plus the
+      // compaction work set so mid-task work can continue.
+      const { boundary } = status
+      const keep = new Set(bootstrapTools)
+      if (boundary >= 0) for (const toolName of compactionTools) keep.add(toolName)
+      return keepTools(assembled, keep, true)
+    } catch (error) {
+      // A filter bug must never brick a session: degrade to the full catalog.
+      warnOnce(`${name}: bootstrap filter failed, exposing the full catalog: ${String((error && error.message) || error)}`)
+      return assembled
+    }
+  })
+
+  // Optionally cap the first model request's output budget while bootstrapping.
+  // Unset (`bootstrapMaxTokens` omitted) means the adapter default flows — the
+  // Minimal tool schema anchors at 256000 without a cap (issue #11).
+  if (bootstrapMaxTokens !== undefined) {
+    // Same registration discipline as the pre-step strip below: `prepend`
+    // keeps this listener the OUTERMOST transform of the agent/request
+    // waterfall for the same registration-order reasons (loader row
+    // application is concurrent; row order alone does not decide listener
+    // order — see issue #6 and upstream PR #13), so a later listener can
+    // never override the first-round budget after we set it.
+    ctx.on('agent/request', async (payload, next) => {
+      const resolved = await next()
+      const agent = payload.agent
+      if (promotion.status(agent).promoted) {
+        // The next request's seed proposal carries the previous header's
+        // maxTokens forward, so the injected cap must be stripped explicitly —
+        // otherwise it would persist for the whole session.
+        if (resolved.maxTokens === bootstrapMaxTokens) {
+          const { maxTokens: _bootstrap, ...rest } = resolved
+          return rest
+        }
+        return resolved
+      }
+      return {
+        ...resolved,
+        maxTokens: bootstrapMaxTokens,
+      }
+    }, { prepend: true })
+  }
+
+  // Strip first-step injected reminders (skill catalog, AGENTS.md) during
+  // bootstrap. Because this listener is the first registered (see the inject
+  // note, the row order in agent.cordis.yml, and `prepend` below), the strip
+  // is the final waterfall transform and actually removes what later
+  // listeners inject.
+  ctx.on('agent/pre-step', async ({ agent }, next) => {
+    // Downstream errors propagate untouched; only this filter's own logic is guarded.
+    const decision = await next()
+    if (decision.kind === 'reject') return decision
+    try {
+      if (promotion.status(agent).promoted || suppressedSources.size === 0) return decision
+      if (!Array.isArray(decision.messages)) return decision
+      const kept = decision.messages.filter((message) => {
+        const kind = message?.source?.kind
+        return typeof kind !== 'string' || !suppressedSources.has(kind)
+      })
+      return kept.length === decision.messages.length ? decision : { ...decision, messages: kept }
+    } catch (error) {
+      // A filter bug must never eat context: degrade to keeping every message.
+      warnOnce(`${name}: pre-step context filter failed, keeping injected context: ${String((error && error.message) || error)}`)
+      return decision
+    }
+  }, { prepend: true })
+}


### PR DESCRIPTION


在现有 `zero-anchored-standard` / `whoami-standard` 变体旁边,新增一个 `anchored-standard-dual-anchor` 变体。相对基础版 `anchored-standard` preset,唯一的改动是 `tool-bootstrap` 配置里的一行:

```yaml
bootstrapMaxTokens: 1024
```

## 为什么

issue #11 的控制变量实验揭示了首轮轨迹的两条独立锚定路径:

- **路径 A(schema 锚定)**:Minimal 工具对(`bash` + `str_replace_editor`)在 adapter 默认 maxTokens 下 5/5 锚定。
- **路径 B(预算锚定)**:`max_tokens=1024` 在 26/32 次运行中产生 "We need..." 风格,且独立于工具描述。

基础版只走路径 A,依赖 adapter 默认 maxTokens 保持在 256000。一旦该默认值漂移(例如被 `adapterDefaults.maxTokens` 覆盖)或 harness 升级导致 Minimal schema 契约断裂,锚定就会退化成 standard-like。本变体让两条路径同时生效:晋升后 cap 会被剥离(复用现有 `tool-bootstrap.mjs` 逻辑),不影响后续实际工作。

`tool-bootstrap.mjs` 未改动——`bootstrapMaxTokens` 本就是已接受的配置键,cap 应用/剥离逻辑完整;本 PR 只是在变体的配置里默认启用它。

## 验证

已在真实 DSH Harness 会话中验证:变体的组合可正常挂载,首请求 `request/header` 显示 `config.maxTokens: 1024` 且 `tools: ["bash", "str_replace_editor"]`,后续请求 cap 被释放。

完整提案与测量细节见 issue #25。
```
