### PR TITLE
fix(persistent-shell): boot bash on hosts without /bin/bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Developed and tested against:
 - repository commit [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/tree/47f943859bef60e4160492346772ded9b24f765a)
 - Node.js 24 on Windows
 
+The persistent shell resolves `shellPath` adaptively: it keeps the
+terminal-bash plugin default `/bin/bash` on hosts where that absolute path
+exists, and falls back to `bash` (PATH lookup) otherwise — e.g. NixOS, where
+bash lives under the Nix store. Hosts that ship `/bin/bash` keep the previous
+behavior exactly; the fallback only activates where the default would make
+every bash call fail with "PTY shell exited during startup".
+
 On the `0.1.0-rc.5` source checkout, `bootstrapMaxTokens` reaches the actual
 first request (the first `request/header` records the cap, `adapterDefaults`
 stays empty), because `llm.prepareCall` only materializes a default maxTokens

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,12 @@ maxTokens 下，Minimal 工具 schema 5/5 锚定（首行 `We need modify…`，
 - 仓库提交 [`47f9438`](https://github.com/deepseek-ai/deepseek-harness/tree/47f943859bef60e4160492346772ded9b24f765a)
 - Windows / Node.js 24
 
+持久 shell 的 `shellPath` 按环境自适应：`/bin/bash` 存在的传统主机保持
+terminal-bash 插件的默认行为不变；仅当该绝对路径不存在（如 NixOS，bash
+位于 Nix store 中）时才回退为 `bash`（PATH 查找）。自带 `/bin/bash` 的主机
+行为与之前完全一致，回退分支只在默认值会导致每次 bash 调用都报
+"PTY shell exited during startup" 的环境上生效。
+
 在 `0.1.0-rc.5` 源码检出上，`bootstrapMaxTokens` 能到达实际首请求（首份
 `request/header` 记录封顶值，`adapterDefaults` 为空），因为 `llm.prepareCall`
 只在提案 config 没有 maxTokens 时才物化默认值。issue #11 观察到的一个预构建 profile

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -120,12 +120,19 @@
   name: '@deepseek-ai/dsh-tool-pwsh'
   disabled: !!js process.platform !== 'win32'
 
-# The Minimal preset's shell: a PTY-backed persistent bash, byte-identical in
-# configuration to the official `minimal` preset's `persistent-shell` group so
-# the first request exposes exactly Minimal's real `bash` schema. The PTY
-# registry is an agent-owned service, so it lives in an entry-local realm; the
-# backend still consumes the host sandbox policy and subprocess implementation,
-# while the tool registers into this agent's scoped catalog.
+# The Minimal preset's shell: a PTY-backed persistent bash, schema-identical
+# to the official `minimal` preset's `persistent-shell` group so the first
+# request exposes exactly Minimal's real `bash` schema. ONE deliberate config
+# difference: an adaptive `shellPath` — the terminal-bash plugin default
+# `/bin/bash` where that absolute path exists (every host that ships it keeps
+# the previous behavior), otherwise a bare `bash` resolved through the same
+# scrubbed PATH the other harness tools use. The fallback exists because
+# `/bin/bash` does not exist on NixOS and other hosts that keep bash
+# elsewhere; there `execvp("/bin/bash")` exits during PTY startup ("PTY shell
+# exited during startup") and every bash call fails. The PTY registry is an
+# agent-owned service, so it lives in an entry-local realm; the backend still
+# consumes the host sandbox policy and subprocess implementation, while the
+# tool registers into this agent's scoped catalog.
 #
 # DISABLED ON WINDOWS: DSH's PTY backend is linux/darwin-only, so the
 # persistent shell cannot serve win32. The `custom-bash` row below registers
@@ -143,6 +150,7 @@
     - id: terminal-bash
       name: '@deepseek-ai/dsh-terminal-bash'
       config:
+        shellPath: !!js "process.getBuiltinModule?.('node:fs')?.existsSync('/bin/bash') ? '/bin/bash' : 'bash'"
         timeoutMs: 300000
 
     - id: persistent-bash

--- a/test/persistent-shell-config.test.mjs
+++ b/test/persistent-shell-config.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+const source = readFileSync(new URL('../preset/agent.cordis.yml', import.meta.url), 'utf8')
+
+/** Extract one `- id: <id>` entry's lines (including its nested config) by indentation. */
+function entryBlock(id) {
+  const lines = source.split('\n')
+  const start = lines.findIndex(line => line.trim() === `- id: ${id}`)
+  assert.ok(start >= 0, `${id} row must exist in preset/agent.cordis.yml`)
+  const indent = (lines[start].match(/^\s*/) ?? [''])[0].length
+  let end = lines.length
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim().length === 0) continue
+    const lineIndent = (line.match(/^\s*/) ?? [''])[0].length
+    if (lineIndent <= indent) {
+      end = index
+      break
+    }
+  }
+  return lines.slice(start, end).join('\n')
+}
+
+/** Read one `key: value` scalar from an entry block. */
+function configValue(block, key) {
+  const match = block.match(new RegExp(`^\\s+${key}:\\s*(.+)$`, 'm'))
+  assert.ok(match, `${key} must be configured in the block`)
+  return match[1].trim()
+}
+
+test('the persistent shell picks /bin/bash when present, else falls back to PATH lookup', () => {
+  const terminalBash = entryBlock('terminal-bash')
+  const shellPath = configValue(terminalBash, 'shellPath')
+  // The loader `!!js` expression keeps the previous absolute default on
+  // hosts that ship /bin/bash and only switches to PATH lookup where it is
+  // missing (NixOS etc.) — where the absolute default makes every bash call
+  // fail with "PTY shell exited during startup".
+  assert.match(shellPath, /existsSync\('\/bin\/bash'\)/)
+  assert.match(shellPath, /'\/bin\/bash'\s*:\s*'bash'/)
+  assert.match(shellPath, /!!js/)
+})
+
+test('the Minimal bash schema rows stay mounted beside the shellPath override', () => {
+  const persistentBash = entryBlock('persistent-bash')
+  assert.match(persistentBash, /Run commands in a bash shell/)
+  assert.equal(configValue(entryBlock('terminal-bash'), 'timeoutMs'), '300000')
+})


### PR DESCRIPTION
## Problem

On NixOS, selecting **Anchored Standard** mounts the `persistent-shell` group, whose `terminal-bash` row relies on the plugin default `shellPath: /bin/bash`. NixOS (and other hosts where bash lives outside `/bin`) has no `/bin/bash`, so the PTY child exits during startup and every `bash` call fails with:

```
PTY shell exited during startup
```

This is a preset regression relative to earlier revisions, which used the Standard sandboxed `bash` tool (PATH-resolved) on POSIX.

## Root cause

`preset/agent.cordis.yml` copied the official `minimal` preset's `persistent-shell` group byte-for-byte, including the implicit `@deepseek-ai/dsh-terminal-bash` default `shellPath: '/bin/bash'`. `node-pty` execs that absolute path, gets `execvp /bin/bash: No such file or directory`, and the terminal session exits before readiness.

## Fix

Add one explicit, adaptive `shellPath` to the `terminal-bash` row:

```yaml
shellPath: !!js "process.getBuiltinModule?.('node:fs')?.existsSync('/bin/bash') ? '/bin/bash' : 'bash'"
```

- Hosts that ship `/bin/bash` keep the previous behavior exactly (no regression on Linux distros or macOS).
- Hosts without `/bin/bash` fall back to `bash` via PATH lookup — the same resolution path the other harness tools already use.
- `process.getBuiltinModule` is available on Node >= 22.19/24 (the repo/harness engines); the optional chaining degrades safely to the PATH fallback if ever absent.

The first-request tool **schema** stays byte-identical to Minimal (`bash` + `str_replace_editor`); only the internal shell executable resolution changed.

## Verification

Against deepseek-harness `47f9438` (0.1.0-rc.5) on NixOS:

1. Reproduced the failure with the real `@deepseek-ai/dsh-terminal-bash` backend + `node-pty` + the `dsh-sandbox-local` bwrap argv profiles:
   - `shellPath: '/bin/bash'` → `PTY shell exited during startup` (workspace-write mode)
2. Confirmed the fix with the real backend:
   - fallback `bash` boots the PTY shell and runs `echo pty-ok-$((6*7))` → `pty-ok-42` under **both** `workspace-write` and `read-only` sandbox modes
3. Parsed/evaluated the modified `agent.cordis.yml` through the harness's own YAML dialect + loader `interpolate` (confirms `shellPath` resolves to `bash` on this host, `/bin/bash` on hosts that have it)
4. `npm test` / `npm run check`: **113/113 pass**, including a new regression test (`test/persistent-shell-config.test.mjs`) that guards the adaptive config.

The user-facing preset install/config in this repo is unchanged apart from this row plus README notes.
