### PR TITLE
feat(tool-bootstrap): promotedTools config for curated promoted catalogs

### DIFF
--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -113,7 +113,21 @@ const PROMOTE_EVENTS = {
 }
 
 /** Every config key this plugin accepts — anything else is a typo. */
-const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools'])
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools', 'promotedTools'])
+
+/**
+ * `promotedTools` selects the post-promotion resident catalog. `'*'` keeps
+ * the FULL assembled catalog unchanged — for presets whose own rows are
+ * already a curated set (e.g. a minimal-gray composition) and should not be
+ * narrowed twice. An explicit array replaces the default keep-set (plus the
+ * discovery tools and dev_tool_search unlocks). Absent, the upstream default
+ * applies: bootstrap pair + discovery tools + unlocks.
+ */
+function parsePromotedTools(value) {
+  if (value === undefined) return undefined
+  if (value === '*') return '*'
+  return stringList(value, 'promotedTools')
+}
 
 /**
  * Context sources stripped from the first request by default. Both are
@@ -193,6 +207,7 @@ export function apply(ctx, config) {
   }
   const bootstrapTools = stringList(source.bootstrapTools, 'bootstrapTools')
   const promoteEvents = parsePromoteOn(source.promoteOn)
+  const promotedTools = parsePromotedTools(source.promotedTools)
   const bootstrapMaxTokens = optionalPositiveInt(source.bootstrapMaxTokens, 'bootstrapMaxTokens')
   const suppressedSources = sourceList(source.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
   // Core work set exposed after a compaction, before re-promotion. Empty
@@ -266,7 +281,13 @@ export function apply(ctx, config) {
         // discovery tools + whatever the model explicitly unlocked via
         // dev_tool_search — instead of dumping the whole Standard catalog at
         // once (the post-promotion regression fix; see the header note).
-        const keep = new Set([...bootstrapTools, ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session)])
+        // `promotedTools: '*'` opts out of narrowing entirely: presets whose
+        // own rows are already a curated set (e.g. minimal-gray compositions)
+        // promote to the full assembled catalog without a second filter.
+        if (promotedTools === '*') return assembled
+        const keep = promotedTools !== undefined
+          ? new Set([...promotedTools, ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session)])
+          : new Set([...bootstrapTools, ...RESIDENT_DISCOVERY_TOOLS, ...unlockedFor(context.agent?.session)])
         return keepTools(assembled, keep, false)
       }
       // Controlled phase: the bootstrap pair; after a compaction, plus the


### PR DESCRIPTION
## 问题

`tool-bootstrap` 的放量目录硬编码为 bootstrap 双工具 + 发现工具 + dev_tool_search 解锁。对于「预设自身行已经是精选目录」的组合（例如 minimal-gray 式灰度预设），放量后会被**二次收窄**——预设声明要常驻的工具全被过滤掉。

## 方案

新增可选配置 `promotedTools`：

- `'*'`：放量后保持完整 assembled 目录不变（预设行已精心挑选，不再收窄）
- 数组：显式指定放量常驻集合（仍叠加发现工具与解锁）

缺省行为与上游完全一致（bootstrap 对 + 发现工具 + 解锁），不影响既有用户。

## 变更

1 文件 +23/-2（ALLOWED_KEYS + parsePromotedTools + promoted 分支分支化）

## 验证

- 已在 minimal-gray 灰度预设实机使用（`promotedTools: '*'`，7 件套放量常驻）
- `node --check` 通过；roster 无 broken
