### PR TITLE
feat(tool-bootstrap): add bootstrapBudgetLadder per-round budget ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Three first-request levers decide the trajectory (issue #11):
    fell standard-like 11/11.
 2. **Output budget** — a 1024 first-request cap also anchored the trajectory
    (26/32), independent of the tool descriptions. The base mode leaves this
-   lever unset (`bootstrapMaxTokens` is opt-in).
+   lever unset (`bootstrapMaxTokens` and `bootstrapBudgetLadder` are opt-in;
+   the ladder relaxes the cap round by round during bootstrap).
 3. **Injected reminders** — the AGENTS.md/CLAUDE.md digest and the
    available-skills reminder. With the skill catalog present the anchor did
    not reproduce at all (0/9); both are stripped during bootstrap.
@@ -154,7 +155,8 @@ waterfall registration order decides the first-request strip):
 |---|---|---|
 | `bootstrapTools` | `[bash, str_replace_editor]` | Tools visible on request #1. |
 | `promoteOn` | `either` | Promotion trigger: `either`, `tool-call`, or `assistant-message`. |
-| `bootstrapMaxTokens` | unset | Optional output cap for request #1; stripped after promotion. |
+| `bootstrapMaxTokens` | unset | Optional flat output cap for the bootstrap requests; stripped after promotion. |
+| `bootstrapBudgetLadder` | unset | Alternative to `bootstrapMaxTokens` (mutually exclusive): `{base, step, warmupRounds}` — bootstrap round N is capped at `base + (N-1)*step` while `N <= warmupRounds`, then released. The tight first-round budget anchors the "We need" trajectory while later rounds open up before promotion. |
 | `suppressedContextSources` | `[agent-instructions, skill-catalog]` | `source.kind` values stripped during bootstrap; `[]` disables the filter. |
 | `compactionTools` | `[]` | Extra tools available between a compaction boundary and re-promotion. |
 
@@ -259,10 +261,13 @@ Export the session JSONL and inspect `request/header` events. Reproduction
 checklist (issue #11 asks for the first two explicitly, because both are the
 variables that decide the anchor):
 
-- **First-request `config.maxTokens` value**: with `bootstrapMaxTokens` unset
+- **First-request `config.maxTokens` value**: with both budget knobs unset
   (the default), the first header records the adapter default (e.g. 256000
-  with `adapterDefaults.maxTokens: true`); with a cap configured it records
-  the cap (e.g. 1024 with no maxTokens adapterDefault).
+  with `adapterDefaults.maxTokens: true`); with `bootstrapMaxTokens` it
+  records the cap (e.g. 1024 with no maxTokens adapterDefault); with
+  `bootstrapBudgetLadder` it records the round-1 rung `base`, and each later
+  bootstrap round records `base + (round-1)*step` until the ladder passes its
+  warmup and the budget releases.
 - **First-request tool schema source**: the first header's `tools` array must
   be exactly `["bash", "str_replace_editor"]` — the official Minimal preset's
   real schemas, not Standard's `pwsh`/`read`.
@@ -294,10 +299,15 @@ npm test
 - A failed tool execution still promotes the session because the durable
   `tool/call` already exists.
 - The first request's output budget is NOT capped by default: the Minimal tool
-  schema anchors at the adapter-default maxTokens, so `bootstrapMaxTokens` is
-  opt-in. When set, the first request is capped and the cap is explicitly
-  stripped after promotion (the next request's seed proposal carries the
-  previous header's maxTokens forward).
+  schema anchors at the adapter-default maxTokens, so both budget knobs are
+  opt-in. `bootstrapMaxTokens` caps every bootstrap request at one value;
+  `bootstrapBudgetLadder` caps round N at `base + (N-1)*step` for
+  `N <= warmupRounds` and then releases — a ladder that keeps the tight
+  first-round anchor (the "We need" trajectory) while giving later bootstrap
+  rounds progressively more room before promotion. Either cap is explicitly
+  stripped after promotion, and the ladder is stripped once it passes its
+  warmup (the next request's seed proposal carries the previous header's
+  maxTokens forward). The two are mutually exclusive.
 - The promoted catalog is the RESIDENT set — the bootstrap pair plus the
   discovery tools plus everything the model unlocked via `dev_tool_search` —
   not the full Standard dump. The Standard sandboxed `bash` row stays disabled

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -34,9 +34,17 @@
 # 5/5 anchored vs 11/11 standard-like for every standard-family schema);
 # after the session records its first durable promotion signal (a tool call OR
 # the first assistant message, default `promoteOn: either`), later steps
-# narrow to the minimal RESIDENT set (see below). `bootstrapMaxTokens` is
-# opt-in for standard-schema bootstraps; unset, the adapter default flows. See
-# tool-bootstrap.mjs for the other triggers.
+# narrow to the minimal RESIDENT set (see below). The first-request output
+# budget is opt-in for standard-schema bootstraps; unset, the adapter default
+# flows. Two mutually exclusive shapes: `bootstrapMaxTokens` — one flat cap
+# (e.g. 1024), stripped after promotion — or `bootstrapBudgetLadder` — a
+# per-round ladder `{base, step, warmupRounds}` where round N (the
+# agent/request turn, 1-based) is capped at `base + (N-1)*step` while
+# `N <= warmupRounds`, then released. The ladder keeps the tight first-round
+# budget that anchors the "We need" trajectory while letting later bootstrap
+# rounds open up before promotion (the AnchorBudgetLadder pattern validated in
+# the RikkaHub port). Both are stripped on promotion. See tool-bootstrap.mjs
+# for the other triggers.
 #
 # The same phase gate suppresses AUTO-INJECTED context on request #1:
 # `suppressedContextSources` lists the `agent/pre-step` message sources the

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -39,6 +39,18 @@
  *     promotion — the next request's seed proposal carries the previous
  *     header's maxTokens forward, so the release must be explicit.
  *
+ *     BUDGET LADDER (local addition): `bootstrapBudgetLadder` is the per-round
+ *     variant — a `{base, step, warmupRounds}` ladder instead of one flat cap.
+ *     Round N (the agent/request `turn`, 1-based) is capped at
+ *     `base + (N-1)*step` while `N <= warmupRounds`; past the warmup the cap is
+ *     released and the adapter default flows. This mirrors the AnchorBudgetLadder
+ *     behavior validated in the RikkaHub port (base 1024, step 512, warmup 4):
+ *     the tight first-request budget that anchors the "We need" trajectory is
+ *     kept, while later bootstrap rounds get progressively more room before
+ *     promotion instead of jumping straight to the full budget. Promotion still
+ *     releases the ladder the same way a flat cap is stripped. `bootstrapMaxTokens`
+ *     and `bootstrapBudgetLadder` are mutually exclusive.
+ *
  *  3. Injected reminders. dsh-agent-instructions and dsh-tool-skill inject
  *     workspace instructions (AGENTS.md) and the skill catalog into the first
  *     step as user messages whenever such content exists. With the skill
@@ -113,7 +125,7 @@ const PROMOTE_EVENTS = {
 }
 
 /** Every config key this plugin accepts — anything else is a typo. */
-const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'suppressedContextSources', 'compactionTools'])
+const ALLOWED_KEYS = new Set(['bootstrapTools', 'promoteOn', 'bootstrapMaxTokens', 'bootstrapBudgetLadder', 'suppressedContextSources', 'compactionTools'])
 
 /**
  * Context sources stripped from the first request by default. Both are
@@ -179,6 +191,35 @@ function optionalPositiveInt(value, field) {
   return value
 }
 
+/** A safe integer that may be zero. */
+function optionalNonNegativeInt(value, field) {
+  if (value === undefined) return undefined
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${name}: ${field} must be a non-negative safe integer`)
+  }
+  return value
+}
+
+/**
+ * Parse the optional budget ladder. `undefined` means no ladder. Returns
+ * `{ base, step, warmupRounds }` with `base` and `warmupRounds` positive safe
+ * integers and `step` a non-negative safe integer. `step` may be zero: a flat
+ * ladder that caps every warmup round at `base`, then releases.
+ */
+function optionalBudgetLadder(value) {
+  if (value === undefined) return undefined
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`${name}: bootstrapBudgetLadder must be an object`)
+  }
+  const base = optionalPositiveInt(value.base, 'bootstrapBudgetLadder.base')
+  const step = optionalNonNegativeInt(value.step, 'bootstrapBudgetLadder.step')
+  const warmupRounds = optionalPositiveInt(value.warmupRounds, 'bootstrapBudgetLadder.warmupRounds')
+  if (base === undefined || step === undefined || warmupRounds === undefined) {
+    throw new TypeError(`${name}: bootstrapBudgetLadder requires base, step, and warmupRounds`)
+  }
+  return { base, step, warmupRounds }
+}
+
 /** Register the per-session bootstrap filters. */
 export function apply(ctx, config) {
   const source = config === undefined ? {} : config
@@ -194,6 +235,10 @@ export function apply(ctx, config) {
   const bootstrapTools = stringList(source.bootstrapTools, 'bootstrapTools')
   const promoteEvents = parsePromoteOn(source.promoteOn)
   const bootstrapMaxTokens = optionalPositiveInt(source.bootstrapMaxTokens, 'bootstrapMaxTokens')
+  const bootstrapBudgetLadder = optionalBudgetLadder(source.bootstrapBudgetLadder)
+  if (bootstrapMaxTokens !== undefined && bootstrapBudgetLadder !== undefined) {
+    throw new TypeError(`${name}: bootstrapMaxTokens and bootstrapBudgetLadder are mutually exclusive`)
+  }
   const suppressedSources = sourceList(source.suppressedContextSources, 'suppressedContextSources', DEFAULT_SUPPRESSED_SOURCES)
   // Core work set exposed after a compaction, before re-promotion. Empty
   // means "no compaction recovery catalog": the session stays on the
@@ -282,33 +327,71 @@ export function apply(ctx, config) {
     }
   })
 
-  // Optionally cap the first model request's output budget while bootstrapping.
-  // Unset (`bootstrapMaxTokens` omitted) means the adapter default flows — the
-  // Minimal tool schema anchors at 256000 without a cap (issue #11).
-  if (bootstrapMaxTokens !== undefined) {
-    // Same registration discipline as the pre-step strip below: `prepend`
-    // keeps this listener the OUTERMOST transform of the agent/request
-    // waterfall for the same registration-order reasons (loader row
-    // application is concurrent; row order alone does not decide listener
-    // order — see issue #6 and upstream PR #13), so a later listener can
-    // never override the first-round budget after we set it.
+  // Optionally shape the first model request's output budget while
+  // bootstrapping: either one flat cap (`bootstrapMaxTokens`) or a per-round
+  // ladder (`bootstrapBudgetLadder`). Unset both and the adapter default flows
+  // — the Minimal tool schema anchors at 256000 without a cap (issue #11).
+  //
+  // Same registration discipline as the pre-step strip below: `prepend` keeps
+  // this listener the OUTERMOST transform of the agent/request waterfall for
+  // the same registration-order reasons (loader row application is concurrent;
+  // row order alone does not decide listener order — see issue #6 and upstream
+  // PR #13), so a later listener can never override the first-round budget
+  // after we set it.
+  if (bootstrapMaxTokens !== undefined || bootstrapBudgetLadder !== undefined) {
+    // The cap to apply on bootstrap round N (1-based), or undefined to release.
+    const capForRound = (round) => {
+      if (bootstrapBudgetLadder !== undefined) {
+        if (round > bootstrapBudgetLadder.warmupRounds) return undefined
+        return bootstrapBudgetLadder.base + (round - 1) * bootstrapBudgetLadder.step
+      }
+      return bootstrapMaxTokens
+    }
+    // The last cap this listener injected per session, so promotion (or a
+    // ladder passing its warmup) can strip exactly what it injected. The next
+    // request's seed proposal carries the previous header's maxTokens forward,
+    // so the release must be explicit.
+    const injectedCaps = new Map()
+    // Every value this ladder could have injected — used to recognize a cap
+    // carried forward from a previous process (resume) that this process never
+    // tracked, mirroring the fixed-cap heuristic below.
+    const ladderRungs = bootstrapBudgetLadder === undefined
+      ? null
+      : Array.from({ length: bootstrapBudgetLadder.warmupRounds }, (_, i) => bootstrapBudgetLadder.base + i * bootstrapBudgetLadder.step)
+
     ctx.on('agent/request', async (payload, next) => {
       const resolved = await next()
       const agent = payload.agent
-      if (promotion.status(agent).promoted) {
-        // The next request's seed proposal carries the previous header's
-        // maxTokens forward, so the injected cap must be stripped explicitly —
-        // otherwise it would persist for the whole session.
-        if (resolved.maxTokens === bootstrapMaxTokens) {
-          const { maxTokens: _bootstrap, ...rest } = resolved
+      const sessionId = agent?.session?.id
+      // Strip a carried-forward cap. The value must be one this listener could
+      // have injected: the tracked per-session cap, the configured fixed cap,
+      // or any rung of the ladder — heuristics that keep working when the
+      // process never injected this session (resume, memoized promotion).
+      const stripInjected = (candidate) => {
+        const tracked = sessionId === undefined ? undefined : injectedCaps.get(sessionId)
+        const fixed = bootstrapBudgetLadder === undefined ? bootstrapMaxTokens : undefined
+        const rung = candidate !== undefined && ladderRungs !== null && ladderRungs.includes(candidate)
+        if (candidate !== undefined && (candidate === tracked || candidate === fixed || rung)) {
+          if (sessionId !== undefined) injectedCaps.delete(sessionId)
+          const { maxTokens: _injected, ...rest } = resolved
           return rest
         }
         return resolved
       }
-      return {
-        ...resolved,
-        maxTokens: bootstrapMaxTokens,
+      if (promotion.status(agent).promoted) {
+        // Promotion ends the bootstrap budget: strip the cap we injected so the
+        // adapter default (or a later caller's value) takes over.
+        return stripInjected(resolved.maxTokens)
       }
+      const round = (Number.isSafeInteger(payload.turn) && payload.turn >= 1 ? payload.turn : 1)
+      const cap = capForRound(round)
+      if (cap === undefined) {
+        // Past the ladder's warmup: release the injected cap too, so the budget
+        // actually opens up instead of carrying the last ladder rung forward.
+        return stripInjected(resolved.maxTokens)
+      }
+      injectedCaps.set(sessionId, cap)
+      return { ...resolved, maxTokens: cap }
     }, { prepend: true })
   }
 

--- a/test/tool-bootstrap.test.mjs
+++ b/test/tool-bootstrap.test.mjs
@@ -161,6 +161,87 @@ test('invalid bootstrapMaxTokens fails at apply time', () => {
   assert.throws(() => register({ ...config, bootstrapMaxTokens: 0 }), /bootstrapMaxTokens/)
 })
 
+// ── bootstrapBudgetLadder (the per-round budget ladder) ─────────────────────
+
+test('bootstrapBudgetLadder caps each bootstrap round at base + (round-1)*step', async () => {
+  const { listeners } = register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 4 } })
+  const resolved = await request(listeners['agent/request'], [], { provider: 'x', model: 'y' }, 'ladder')
+  assert.equal(resolved.maxTokens, 1024)
+})
+
+test('bootstrapBudgetLadder resolves the cap from the agent/request turn', async () => {
+  const { listeners } = register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 4 } })
+  const rounds = [1, 2, 3, 4].map((turn) =>
+    listeners['agent/request']({ agent: agent([], 'ladder'), turn, step: 1 }, async () => ({ provider: 'x', model: 'y' })),
+  )
+  const caps = await Promise.all(rounds)
+  assert.deepEqual(caps.map((resolved) => resolved.maxTokens), [1024, 1536, 2048, 2560])
+})
+
+test('bootstrapBudgetLadder releases the cap past the warmup rounds', async () => {
+  const { listeners } = register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 2 } })
+  const warm = await listeners['agent/request'](
+    { agent: agent([], 'ladder'), turn: 2, step: 1 },
+    async () => ({ provider: 'x', model: 'y' }),
+  )
+  assert.equal(warm.maxTokens, 1536)
+  const past = await listeners['agent/request'](
+    { agent: agent([], 'ladder'), turn: 3, step: 1 },
+    async () => ({ provider: 'x', model: 'y', maxTokens: 1536 }),
+  )
+  assert.equal(past.maxTokens, undefined)
+})
+
+test('bootstrapBudgetLadder with a zero step is a flat warmup cap', async () => {
+  const { listeners } = register({ ...config, bootstrapBudgetLadder: { base: 2048, step: 0, warmupRounds: 3 } })
+  const caps = await Promise.all([1, 2, 3].map((turn) =>
+    listeners['agent/request']({ agent: agent([], 'ladder'), turn, step: 1 }, async () => ({ provider: 'x', model: 'y' })),
+  ))
+  assert.deepEqual(caps.map((resolved) => resolved.maxTokens), [2048, 2048, 2048])
+})
+
+test('bootstrapBudgetLadder strips the injected cap after promotion', async () => {
+  const { listeners } = register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 4 } })
+  const resolved = await request(
+    listeners['agent/request'],
+    [{ type: 'tool/call' }],
+    { provider: 'x', model: 'y', maxTokens: 1024 },
+    'ladder',
+  )
+  assert.equal(resolved.maxTokens, undefined)
+})
+
+test('bootstrapBudgetLadder keeps a non-injected maxTokens after promotion', async () => {
+  const { listeners } = register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 4 } })
+  const resolved = await request(
+    listeners['agent/request'],
+    [{ type: 'assistant/message' }],
+    { provider: 'x', model: 'y', maxTokens: 256000 },
+    'ladder',
+  )
+  assert.equal(resolved.maxTokens, 256000)
+})
+
+test('bootstrapBudgetLadder registers with prepend like the fixed cap', () => {
+  const { hookOptions } = register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 4 } })
+  assert.deepEqual(hookOptions['agent/request'], { prepend: true })
+})
+
+test('bootstrapMaxTokens and bootstrapBudgetLadder are mutually exclusive', () => {
+  assert.throws(
+    () => register({ ...config, bootstrapMaxTokens: 1024, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 4 } }),
+    /mutually exclusive/,
+  )
+})
+
+test('invalid bootstrapBudgetLadder values fail at apply time', () => {
+  assert.throws(() => register({ ...config, bootstrapBudgetLadder: 42 }), /bootstrapBudgetLadder/)
+  assert.throws(() => register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512 } }), /bootstrapBudgetLadder/)
+  assert.throws(() => register({ ...config, bootstrapBudgetLadder: { base: 0, step: 512, warmupRounds: 4 } }), /bootstrapBudgetLadder.base/)
+  assert.throws(() => register({ ...config, bootstrapBudgetLadder: { base: 1024, step: -1, warmupRounds: 4 } }), /bootstrapBudgetLadder.step/)
+  assert.throws(() => register({ ...config, bootstrapBudgetLadder: { base: 1024, step: 512, warmupRounds: 0 } }), /bootstrapBudgetLadder.warmupRounds/)
+})
+
 test('pre-step filter registers with prepend before every other listener', () => {
   const { hookOptions } = register()
   assert.equal(hookOptions['agent/pre-step']?.prepend, true)


### PR DESCRIPTION
## Summary

Adds an optional `bootstrapBudgetLadder` config to the `tool-bootstrap` plugin, mutually exclusive with `bootstrapMaxTokens`:

- `{base, step, warmupRounds}` — bootstrap round N (the `agent/request` turn, 1-based) is capped at `base + (N-1)*step` while `N <= warmupRounds`, then the cap is released and the adapter default flows.
- Keeps the tight first-round budget that anchors the "We need" trajectory (issue #11) while letting later bootstrap rounds open up progressively before promotion.
- The cap is stripped on promotion; the ladder is also stripped once it passes its warmup (the next request's seed proposal carries the previous header's maxTokens forward).
- Both budget knobs stay opt-in; unset (the default) still flows the adapter default. Unknown keys still fail at mount.

This mirrors the AnchorBudgetLadder behavior validated in the RikkaHub port (base 1024 / step 512 / warmup 4).

## Changes

- `preset/tool-bootstrap.mjs`: `bootstrapBudgetLadder` parsing/validation, per-round cap resolution, explicit cap stripping on promotion and past warmup, mutual-exclusion check with `bootstrapMaxTokens`.
- `test/tool-bootstrap.test.mjs`: 9 new zero-dependency tests — round capping, warmup release, flat (zero-step) ladder, promotion strip, non-injected maxTokens preserved, prepend registration, mutual exclusion, invalid configs.
- `README.md`, `preset/agent.cordis.yml`: document the new knob.

## Verification

- `npm run check` passes: 115 tests green (was 106), no sync drift.