### PR TITLE
fix: prevent instruction hint reinjection after resume

### DIFF
--- a/preset/instruction-hint.mjs
+++ b/preset/instruction-hint.mjs
@@ -125,7 +125,18 @@ export function apply(ctx, config) {
     try {
       if (promotion.status(agent).promoted !== true) return decision
       const session = agent.session
-      if (session === undefined || hinted.has(session.id)) return decision
+      if (session === undefined) return decision
+      if (hinted.has(session.id)) return decision
+      const hintId = `instruction-hint-${session.id}`
+      const persisted = Array.isArray(session.events) && session.events.some((event) => (
+        event.type === 'user/message'
+        && event.data?.id === hintId
+        && event.data?.source?.kind === 'instruction-hint'
+      ))
+      if (persisted) {
+        hinted.add(session.id)
+        return decision
+      }
       hinted.add(session.id)
 
       const fs = ctx.get('fs')
@@ -163,7 +174,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: hintId,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/shared/instruction-hint.mjs
+++ b/shared/instruction-hint.mjs
@@ -125,7 +125,18 @@ export function apply(ctx, config) {
     try {
       if (promotion.status(agent).promoted !== true) return decision
       const session = agent.session
-      if (session === undefined || hinted.has(session.id)) return decision
+      if (session === undefined) return decision
+      if (hinted.has(session.id)) return decision
+      const hintId = `instruction-hint-${session.id}`
+      const persisted = Array.isArray(session.events) && session.events.some((event) => (
+        event.type === 'user/message'
+        && event.data?.id === hintId
+        && event.data?.source?.kind === 'instruction-hint'
+      ))
+      if (persisted) {
+        hinted.add(session.id)
+        return decision
+      }
       hinted.add(session.id)
 
       const fs = ctx.get('fs')
@@ -163,7 +174,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: hintId,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/test/instruction-hint.test.mjs
+++ b/test/instruction-hint.test.mjs
@@ -67,6 +67,24 @@ test('after promotion ONE hint is injected once per session', async () => {
   assert.equal(second.messages.length, 1)
 })
 
+test('a persisted hint prevents reinjection after the plugin reloads', async () => {
+  const promoted = { type: 'assistant/message', seq: 1, data: {} }
+  const firstMount = register()
+  const first = await firstMount.listeners['agent/pre-step'](
+    { agent: { session: session([promoted]) } },
+    async () => decision(),
+  )
+  const persistedHint = { type: 'user/message', seq: 2, data: first.messages[1] }
+
+  const reloadedMount = register()
+  const resumed = await reloadedMount.listeners['agent/pre-step'](
+    { agent: { session: session([promoted, persistedHint]) } },
+    async () => decision(),
+  )
+
+  assert.equal(resumed.messages.length, 1)
+})
+
 test('no instruction files found → no hint message', async () => {
   const listeners = {}
   const fs = {

--- a/whoami-standard/instruction-hint.mjs
+++ b/whoami-standard/instruction-hint.mjs
@@ -125,7 +125,18 @@ export function apply(ctx, config) {
     try {
       if (promotion.status(agent).promoted !== true) return decision
       const session = agent.session
-      if (session === undefined || hinted.has(session.id)) return decision
+      if (session === undefined) return decision
+      if (hinted.has(session.id)) return decision
+      const hintId = `instruction-hint-${session.id}`
+      const persisted = Array.isArray(session.events) && session.events.some((event) => (
+        event.type === 'user/message'
+        && event.data?.id === hintId
+        && event.data?.source?.kind === 'instruction-hint'
+      ))
+      if (persisted) {
+        hinted.add(session.id)
+        return decision
+      }
       hinted.add(session.id)
 
       const fs = ctx.get('fs')
@@ -163,7 +174,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: hintId,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/zero-anchored-standard/instruction-hint.mjs
+++ b/zero-anchored-standard/instruction-hint.mjs
@@ -125,7 +125,18 @@ export function apply(ctx, config) {
     try {
       if (promotion.status(agent).promoted !== true) return decision
       const session = agent.session
-      if (session === undefined || hinted.has(session.id)) return decision
+      if (session === undefined) return decision
+      if (hinted.has(session.id)) return decision
+      const hintId = `instruction-hint-${session.id}`
+      const persisted = Array.isArray(session.events) && session.events.some((event) => (
+        event.type === 'user/message'
+        && event.data?.id === hintId
+        && event.data?.source?.kind === 'instruction-hint'
+      ))
+      if (persisted) {
+        hinted.add(session.id)
+        return decision
+      }
       hinted.add(session.id)
 
       const fs = ctx.get('fs')
@@ -163,7 +174,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: hintId,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },


### PR DESCRIPTION
## Problem

`instruction-hint` promises one durable, resume-safe hint per Session, but delivery was tracked only in a process-local `Set`. A fresh plugin mount, including a CLI resume in a new process, forgot the prior delivery and persisted the same hint again.

## Change

- Detect an already-persisted hint from the Session event log using both the Session-specific message id and the `instruction-hint` source kind.
- Memoize that durable result for later steps in the same process.
- Keep the existing in-process guard for steps that occur before the injected message is persisted.
- Synchronize the shared implementation into all three self-contained preset directories.
- Add a regression test that mounts a fresh plugin instance with the first hint represented as a durable `user/message` event.

The hint text, promotion rules, tool catalogs, and compaction behavior are unchanged.

## Verification

- `node --test test/instruction-hint.test.mjs` — 7 passed
- `npm run check` — sync check passed; 107 tests passed
- `git diff --check` — passed
- Independent review of commit `68424a0` by Codex, DeepSeek Harness, and Kimi Code — all passed with no findings
- DeepSeek Harness integration check against the pinned Harness source and installed `dsh-session` package — confirmed the durable `user/message` event shape and no reinjection after plugin reload

## AI Assistance

OpenAI Codex diagnosed the cross-process lifecycle gap, implemented the fix and regression test, and ran the verification commands above. Independent reviewer runs using OpenAI Codex, DeepSeek Harness, and Kimi Code reviewed the exact committed change for correctness, lifecycle safety, and minimality; all returned PASS. DeepSeek Harness additionally verified the persistence behavior against the real Session store.
