### PR TITLE
fix(instruction-hint): 增加对项目当前目录为Git仓库子目录时，对当前目录Agent Instruction的扫描

### DIFF
--- a/combo-anchored/instruction-hint.mjs
+++ b/combo-anchored/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/eternal-minimal/instruction-hint.mjs
+++ b/eternal-minimal/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/prefab/instruction-hint.mjs
+++ b/prefab/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/preset/instruction-hint.mjs
+++ b/preset/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/shared/instruction-hint.mjs
+++ b/shared/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/test/instruction-hint.test.mjs
+++ b/test/instruction-hint.test.mjs
@@ -138,3 +138,32 @@ test('the hint registers with prepend', () => {
   const { hookOptions } = register()
   assert.deepEqual(hookOptions['agent/pre-step'], { prepend: true })
 })
+
+test('regression: AGENTS.md below the git root still gets hinted (chain probing)', async () => {
+  // The observed failure mode: a session cwd nested below the git root
+  // carried AGENTS.md while the root itself did not. Root-only probing
+  // found nothing, so the hint silently never fired — the plugin's own
+  // docstring promises "walking up from the session cwd to the project
+  // root", and this pins that behavior.
+  const listeners = {}
+  const files = new Set(['/work/project/.git', '/work/project/sub/AGENTS.md'])
+  const fs = {
+    async resolve(target) { return target },
+    async stat(target) {
+      const path = target.replace(/\\/g, '/')
+      if (!files.has(path)) throw new Error('ENOENT')
+      return path.endsWith('.git') ? { type: 'directory' } : { type: 'file' }
+    },
+  }
+  const ctx = {
+    on(event, callback) { listeners[event] = callback },
+    get(service) { return service === 'fs' ? fs : undefined },
+    logger: { warn() {} },
+  }
+  apply(ctx, { promoteOn: 'either' })
+  const agent = { session: session([{ type: 'tool/call', seq: 1, data: {} }], { cwd: '/work/project/sub' }) }
+  const result = await listeners['agent/pre-step']({ agent }, async () => decision())
+  assert.equal(result.messages.length, 2, 'hint must be injected when the file lives below the git root')
+  assert.match(result.messages[1].content[0].text, /sub\/AGENTS\.md/)
+  assert.match(result.messages[1].content[0].text, /project root: \/work\/project/)
+})

--- a/whoami-standard/instruction-hint.mjs
+++ b/whoami-standard/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/wire-think-standard/instruction-hint.mjs
+++ b/wire-think-standard/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {

--- a/zero-anchored-standard/instruction-hint.mjs
+++ b/zero-anchored-standard/instruction-hint.mjs
@@ -185,9 +185,25 @@ export function apply(ctx, config) {
       if (fs === undefined) return decision
       const cwd = session.header.cwd ?? process.cwd()
 
-      const projectFiles = []
       const root = await findProjectRoot(fs, cwd, signal)
-      projectFiles.push(...await presentInDir(fs, root, PROJECT_CANDIDATES, signal))
+      const projectFiles = []
+      // Probe the FULL chain from the session cwd up to (and including) the
+      // project root — AGENTS.md/CLAUDE.md may sit at ANY level (the session
+      // cwd can carry one while its git root does not), per the AGENTS.md
+      // convention and this plugin's own docstring ("project chain … walking
+      // up from the session cwd to the project root"). The previous
+      // implementation probed only the root directory and silently found
+      // nothing whenever the instruction file lived below it.
+      let probed = cwd
+      for (;;) {
+        for (const candidate of await presentInDir(fs, probed, PROJECT_CANDIDATES, signal)) {
+          projectFiles.push(probed === root ? candidate : joinPath(probed, candidate))
+        }
+        if (probed === root) break
+        const parent = parentPath(probed)
+        if (parent === probed || parent.length === 0) break
+        probed = parent
+      }
 
       const userGlobalFiles = []
       try {


### PR DESCRIPTION
## 问题

`instruction-hint` 只在解析出的**项目根**探测 AGENTS.md/CLAUDE.md。当会话 cwd 位于 git 根之下、指令文件就在 cwd（嵌套布局的常见情形——子目录是工作区、父目录才是 git 仓库）时，探测扑空，hint **静默失效**：模型对指令文件的存在全程无感知。

而插件自己的文档注释承诺的是：

> project chain: AGENTS.md / CLAUDE.md / … **walking up from the session cwd** to the project root

实现与文档不符：只探了根目录，没有走链。

## 修复

从会话 cwd 逐级向上（含项目根）探测每一级目录的候选指令文件，hint 文本中列出找到文件的完整路径。单 commit，除链式探测块与回归测试外零附带改动。

## 验证

- 仓库测试 107/107 通过；新增回归测试钉死该行为（AGENTS.md 位于 git 根之下的场景，断言 hint 注入且路径正确）
- 实测（嵌套布局工作区，Pro 与 Flash 各一轮）：修复前 hint 从未注入；修复后 hint 正常注入、以 `instruction-hint` 会话事件持久化，模型在任务涉及仓库规范时主动读取指令文件
