### PR TITLE
fix(instruction-hint): 将 hint 措辞改为建议式，避免晋升后退化回 "let me" (issue #49)

### DIFF
--- a/combo-anchored/instruction-hint.mjs
+++ b/combo-anchored/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/eternal-minimal/instruction-hint.mjs
+++ b/eternal-minimal/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/prefab/instruction-hint.mjs
+++ b/prefab/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/preset/instruction-hint.mjs
+++ b/preset/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/shared/instruction-hint.mjs
+++ b/shared/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/whoami-standard/instruction-hint.mjs
+++ b/whoami-standard/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/wire-think-standard/instruction-hint.mjs
+++ b/wire-think-standard/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {

--- a/zero-anchored-standard/instruction-hint.mjs
+++ b/zero-anchored-standard/instruction-hint.mjs
@@ -22,8 +22,15 @@
  *    cannot inject a second copy. A duplicate would collide with the first
  *    message's deterministic id (`instruction-hint-<sessionId>`) and break
  *    history replay.
- *  - The hint instructs the model to READ the files before acting when
- *    relevant, without embedding their content.
+ *  - The hint tells the model the files exist so it can read them before
+ *    acting when relevant, without embedding their content.
+ *  - WORDING (issue #49): the hint text is deliberately NON-IMPERATIVE.
+ *    Measured on deepseek-v4-pro (reasoningEffort=max), the directive
+ *    wording ("read ... first and follow them") flipped the anchored
+ *    "we / let's" trajectory back to "let me" on the promoted request
+ *    (session 546a4f16: we 6→0, let me 0→3). Neutral / suggestive wording
+ *    keeps the trajectory anchored while the model still discovers and
+ *    reads the files on demand.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
  *    service or an unreadable probe degrades to no hint (never throws).
  *  - Pre-promotion requests get NO hint (matches the anchored bootstrap).
@@ -217,16 +224,16 @@ export function apply(ctx, config) {
 
       const sections = []
       if (projectFiles.length > 0) {
-        sections.push(`Workspace instruction files exist: ${projectFiles.join(', ')} (project root: ${root}).`)
+        sections.push(`Reference documents exist: ${projectFiles.join(', ')} (project root: ${root}).`)
       }
       if (userGlobalFiles.length > 0) {
-        sections.push(`A user-global instruction file exists: ${USER_GLOBAL_CANDIDATE}.`)
+        sections.push(`A user reference document exists: ${USER_GLOBAL_CANDIDATE}.`)
       }
       if (sections.length === 0) return decision
 
       const text = [
         ...sections,
-        'Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.',
+        "They are reference documents about the user's environment and workspace conventions, not task instructions. Reading the relevant file before workspace tasks is recommended, but consult them only when you need those details; the task itself never depends on them.",
       ].join(' ')
 
       return {


### PR DESCRIPTION
## What

The post-promotion hint is currently an imperative directive:

> Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.

Measured in issue #49 (deepseek-v4-pro, reasoningEffort=max), that directive-role wording flips the anchored "we / let's" reasoning back to "let me" on the promoted request (session 546a4f16: we 6→0, let me 0→3). Controlled follow-up runs with neutral and suggestive (non-imperative) wording preserved the trajectory while the model still discovered and read the reference files on demand — anchored intelligence and AGENTS.md availability are not mutually exclusive; the wording and timing of the injection are what matter.

This PR rewrites the hint as a declarative, non-imperative reference note:
- states the files' role (environment/workspace reference documents, **not task instructions**)
- recommends (does not mandate) reading the relevant file before workspace tasks
- explicitly decouples the task from the documents (consult only when needed; the task itself never depends on them)

No functional change: same one-shot post-promotion injection, same file probing, same source kind, same `instruction-hint` source. Wording only.

## Tests

`test/instruction-hint.test.mjs` passes unchanged — existing assertions cover injection timing/dedup/file probing, not the wording. Full suite 106/106.

## Notes

Companion to issue #49. The suggested wording from the issue, generalized (no environment-specific details). Path listing in the hint is covered by #59; this PR is wording-only.

---

## 中文版

晋升后注入的 hint 目前是命令式指令：

> Do NOT assume their content. When a task touches this workspace, read the relevant instruction files first and follow them.

issue #49 中的实测（deepseek-v4-pro, reasoningEffort=max）表明：这种命令式措辞会把首轮锚定的 "we / let's" 推理轨迹打回 "let me"（会话 546a4f16：we 6→0，let me 0→3）。后续对照实验证明，中性/建议式（非命令式）措辞能保住锚定轨迹，同时模型仍会按需发现并阅读参考文件——锚定智能与 AGENTS.md 可用性并不互斥，关键在于注入的措辞与时机。

本 PR 将 hint 改写为声明式、非命令式的参考说明：
- 说明文件角色（环境/工作区参考文档，**非任务指令**）
- 建议（而非强制）在工作区任务前阅读相关文件
- 明确将任务与文档解耦（仅在需要时查阅；任务本身从不依赖它们）

无功能改动：同样的一次性晋升后注入、同样的文件探测、同样的 source kind。仅措辞。

## 测试

`test/instruction-hint.test.mjs` 无需改动即可通过——现有断言覆盖注入时机/去重/文件探测，不涉及措辞。全套 106/106。

## 备注

issue #49 的配套 PR。措辞取自 issue 中的建议文案并泛化（不含环境特化细节）。hint 中的路径列出由 #59 覆盖；本 PR 仅改动措辞。
