### PR TITLE
docs: fix grammar - missing comma after introductory phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Three first-request levers decide the trajectory (issue #11):
    (26/32), independent of the tool descriptions. The base mode leaves this
    lever unset (`bootstrapMaxTokens` is opt-in).
 3. **Injected reminders** — the AGENTS.md/CLAUDE.md digest and the
-   available-skills reminder. With the skill catalog present the anchor did
+   available-skills reminder. With the skill catalog present, the anchor did
    not reproduce at all (0/9). The base mode now suppresses EVERY automatic
    injection during bootstrap at the harness's two unified injection paths
    (the `context-gate` plugin), not just the two measured ones.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 104-105).

## Problem

Missing comma after the introductory prepositional phrase 'With the skill catalog present'. Without the comma, the sentence is momentarily ambiguous about where the introductory clause ends.

The problematic text:
```markdown
With the skill catalog present the anchor did not reproduce at all (0/9).
```

## Fix

Replaced with:
```markdown
With the skill catalog present, the anchor did not reproduce at all (0/9).
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

## Audit Metadata

| Field | Value |
|-------|-------|
| **Fingerprint** | `c735ae04554c9d23` |
| **Severity** | minor |
| **Category** | grammar |
| **Audit Date** | 2026-08-17 |