### PR TITLE
docs: fix grammar - awkward adjective order in 'Minimal complete system prompt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ however, gives up the Standard preset's broader tool set.
 
 Anchored Standard separates initial trajectory selection from later tool use:
 
-1. Keep the Minimal complete system prompt.
+1. Keep the complete Minimal system prompt.
 2. Expose the Minimal preset's REAL tool schemas — persistent `bash` +
    `str_replace_editor`, byte-identical to the official Minimal composition —
    on the first model request (lever 1 above).


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 118).

## Problem

Awkward adjective order. 'Minimal complete system prompt' places the proper-noun adjective 'Minimal' before the general adjective 'complete', which is unusual in English. The intended meaning is 'the complete system prompt of the Minimal preset'.

The problematic text:
```markdown
Keep the Minimal complete system prompt.
```

## Fix

Replaced with:
```markdown
Keep the complete Minimal system prompt.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text

## Audit Metadata

| Field | Value |
|-------|-------|
| **Fingerprint** | `30f05e56121dc2b1` |
| **Severity** | minor |
| **Category** | grammar |
| **Audit Date** | 2026-08-17 |