### PR TITLE
fix(verify): honor stopAfterFirstAssistant and add regression tests

### DIFF
--- a/test/first-assistant-canceller.test.mjs
+++ b/test/first-assistant-canceller.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createFirstAssistantCanceller } from '../verify/first-assistant-canceller.mjs'
+
+/** Minimal fake agent surface: session events plus a cancel recorder. */
+function agent(events = []) {
+  const calls = []
+  return {
+    calls,
+    session: { events },
+    cancel(reason) {
+      calls.push(reason)
+    },
+  }
+}
+
+/** In-memory timer pair so tests drive ticks deterministically. */
+function fakeTimers() {
+  let nextId = 1
+  const timers = new Map()
+  return {
+    timers,
+    setInterval(fn, ms) {
+      const id = nextId += 1
+      timers.set(id, { fn, ms })
+      return id
+    },
+    clearInterval(id) {
+      timers.delete(id)
+    },
+    fireAll() {
+      for (const timer of [...timers.values()]) timer.fn()
+    },
+  }
+}
+
+test('disabled mode schedules no timer and returns no stop handle', () => {
+  const timers = fakeTimers()
+  const subject = agent([{ type: 'assistant/message', seq: 10 }])
+  const stop = createFirstAssistantCanceller({
+    agent: subject,
+    firstSeq: 5,
+    enabled: false,
+    setIntervalFn: timers.setInterval,
+    clearIntervalFn: timers.clearInterval,
+  })
+  assert.equal(stop, undefined)
+  assert.equal(timers.timers.size, 0)
+  timers.fireAll()
+  assert.deepEqual(subject.calls, [])
+})
+
+test('enabled mode cancels once when a durable assistant message at/after firstSeq appears', () => {
+  const timers = fakeTimers()
+  const subject = agent()
+  const stop = createFirstAssistantCanceller({
+    agent: subject,
+    firstSeq: 10,
+    enabled: true,
+    intervalMs: 100,
+    setIntervalFn: timers.setInterval,
+    clearIntervalFn: timers.clearInterval,
+  })
+  assert.equal(timers.timers.size, 1)
+  assert.deepEqual(subject.calls, [])
+  subject.session.events.push({ type: 'assistant/message', seq: 10 })
+  timers.fireAll()
+  timers.fireAll()
+  assert.equal(subject.calls.length, 1)
+  assert.deepEqual(subject.calls[0], { kind: 'user' })
+  stop.stop()
+})
+
+test('events before firstSeq never cancel', () => {
+  const timers = fakeTimers()
+  const subject = agent([{ type: 'assistant/message', seq: 9 }])
+  createFirstAssistantCanceller({
+    agent: subject,
+    firstSeq: 10,
+    enabled: true,
+    setIntervalFn: timers.setInterval,
+    clearIntervalFn: timers.clearInterval,
+  })
+  timers.fireAll()
+  assert.deepEqual(subject.calls, [])
+})
+
+test('stop() disarms the watcher before any later event can cancel', () => {
+  const timers = fakeTimers()
+  const subject = agent()
+  const stop = createFirstAssistantCanceller({
+    agent: subject,
+    firstSeq: 10,
+    enabled: true,
+    setIntervalFn: timers.setInterval,
+    clearIntervalFn: timers.clearInterval,
+  })
+  stop.stop()
+  assert.equal(timers.timers.size, 0)
+  subject.session.events.push({ type: 'assistant/message', seq: 10 })
+  timers.fireAll()
+  assert.deepEqual(subject.calls, [])
+})

--- a/verify/first-assistant-canceller.mjs
+++ b/verify/first-assistant-canceller.mjs
@@ -1,0 +1,50 @@
+/**
+ * first-assistant-canceller — dependency-free scheduling helper for the
+ * verify-runner's optional "stop after the first durable assistant message"
+ * mode.
+ *
+ * Why a separate file: `verify-runner.mjs` imports DeepSeek Harness packages,
+ * which the zero-dependency repository test suite cannot import. Keeping this
+ * tiny scheduler free of those imports lets the unit tests cover the exact
+ * behavior issues #56/#57 reported — the timer must ONLY exist when the mode
+ * is enabled, it must cancel exactly once, and `stop()` must disarm it.
+ */
+
+/**
+ * Watch an agent's durable session events and cancel the agent as soon as the
+ * first `assistant/message` at or after `firstSeq` appears.
+ *
+ * @param options.agent - the running agent ({ session, cancel }).
+ * @param options.firstSeq - events with a lower seq predate this run.
+ * @param options.enabled - `false` returns `undefined` and schedules nothing.
+ * @param options.intervalMs - poll interval.
+ * @param options.setIntervalFn / clearIntervalFn - timer injections for tests.
+ * @returns a stop handle, or `undefined` when disabled.
+ */
+export function createFirstAssistantCanceller({
+  agent,
+  firstSeq,
+  enabled,
+  intervalMs = 100,
+  setIntervalFn = setInterval,
+  clearIntervalFn = clearInterval,
+}) {
+  if (!enabled) return undefined
+  let cancelled = false
+  const handle = setIntervalFn(() => {
+    if (cancelled) return
+    const hit = agent?.session?.events?.some(
+      (event) => event.type === 'assistant/message' && (event.seq ?? 0) >= (firstSeq ?? 0),
+    )
+    if (hit) {
+      cancelled = true
+      agent?.cancel?.({ kind: 'user' })
+    }
+  }, intervalMs)
+  return {
+    stop() {
+      cancelled = true
+      clearIntervalFn(handle)
+    },
+  }
+}

--- a/verify/verify-runner.mjs
+++ b/verify/verify-runner.mjs
@@ -29,6 +29,7 @@ import z from '@deepseek-ai/schemastery'
 import { installModelSelection } from '@deepseek-ai/dsh-agent'
 import { createUserMessage } from '@deepseek-ai/dsh-llm'
 import { SessionId } from '@deepseek-ai/dsh-session'
+import { createFirstAssistantCanceller } from './first-assistant-canceller.mjs'
 
 /** Stable Cordis plugin name. */
 export const name = 'verify-runner'
@@ -100,23 +101,21 @@ async function run(ctx, config, io) {
   const firstSeq = agent.session.seq
 
   // Optional: cancel as soon as the first assistant message is durable, so a
-  // verbose multi-tool run does not burn the whole task budget.
-  let cancelled = false
-  const watch = setInterval(() => {
-    if (cancelled) return
-    const hit = agent.session.events.some((event) => event.type === 'assistant/message' && event.seq >= firstSeq)
-    if (hit) {
-      cancelled = true
-      agent.cancel({ kind: 'user' })
-    }
-  }, 100)
+  // verbose multi-tool run does not burn the whole task budget. The watcher is
+  // scheduled ONLY when the mode is enabled (issues #56/#57): with the default
+  // `stopAfterFirstAssistant: false` the run must continue through promotion.
+  const firstAssistantWatch = createFirstAssistantCanceller({
+    agent,
+    firstSeq,
+    enabled: config.stopAfterFirstAssistant,
+  })
 
   agent.followup(createUserMessage({
     content: [{ type: 'text', text: config.task }],
     source: { kind: 'user' },
   }))
   await agent.whenIdle()
-  clearInterval(watch)
+  firstAssistantWatch?.stop()
   await sessions.flush(agent.session)
 
   // Report: session identity, every request header, then the first assistant reply.


### PR DESCRIPTION
Fixes #56 and #57.

## Problem

`verify/verify-runner.mjs` declares `stopAfterFirstAssistant` (default `false`) in its schema and documents it, but never reads it. The first-assistant cancellation timer is installed unconditionally, so every verify run aborts after the first durable `assistant/message` and the post-promotion `request/header` changes can never be observed.

## Fix

- Gate the watcher on `config.stopAfterFirstAssistant`: the default run now continues through promotion and reports every header change.
- Extract the timer into a dependency-free helper (`verify/first-assistant-canceller.mjs`) so the zero-dependency repository test suite can cover the behavior.
- Add 4 regression tests:
  - disabled mode schedules nothing and never cancels;
  - enabled mode cancels exactly once at/after `firstSeq`;
  - pre-`firstSeq` assistant events do not cancel;
  - `stop()` disarms the timer.

## Validation

- `npm run check`: 195/195 passing.
- Behavior unchanged when `--stop-after-first-assistant` is passed.