### PR TITLE
fix: normalize Git Bash workdir paths on Windows

### DIFF
--- a/combo-anchored/custom-bash.mjs
+++ b/combo-anchored/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/eternal-minimal/custom-bash.mjs
+++ b/eternal-minimal/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/prefab/custom-bash.mjs
+++ b/prefab/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/preset/custom-bash.mjs
+++ b/preset/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/shared/custom-bash.mjs
+++ b/shared/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/test/custom-bash.test.mjs
+++ b/test/custom-bash.test.mjs
@@ -4,7 +4,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { apply, bashCandidates, name, inject } from '../shared/custom-bash.mjs'
+import { apply, bashCandidates, name, inject, normalizeGitBashWorkdir } from '../shared/custom-bash.mjs'
 
 function register(config) {
   const registered = []
@@ -89,6 +89,56 @@ test('execute passes the session cwd by default and honors an explicit workdir',
   assert.equal(spawnCalls[0].cwd, 'C:/work')
   await tool.execute({ command: 'pwd', workdir: 'D:/other' }, exec())
   assert.equal(spawnCalls[1].cwd, 'D:/other')
+})
+
+test('normalizeGitBashWorkdir converts /e/foo on Windows and leaves Unix paths alone', () => {
+  assert.equal(normalizeGitBashWorkdir('/e/yaogan-jingjiaozheng', 'win32'), 'E:\\yaogan-jingjiaozheng')
+  assert.equal(normalizeGitBashWorkdir('/e', 'win32'), 'E:\\')
+  assert.equal(normalizeGitBashWorkdir('/usr/bin', 'win32'), '/usr/bin')
+  assert.equal(normalizeGitBashWorkdir('/tmp', 'win32'), '/tmp')
+  assert.equal(normalizeGitBashWorkdir('/e/foo', 'linux'), '/e/foo')
+  assert.equal(normalizeGitBashWorkdir('D:/other', 'win32'), 'D:/other')
+})
+
+test('execute converts a Git Bash workdir on Windows (issue #55)', async () => {
+  const { tool, spawnCalls } = register({ bashPath: 'C:/Program Files/Git/bin/bash.exe' })
+  await tool.execute({ command: 'pwd', workdir: '/e/yaogan-jingjiaozheng' }, exec())
+  if (process.platform === 'win32') {
+    assert.equal(spawnCalls[0].cwd, 'E:\\yaogan-jingjiaozheng')
+  } else {
+    assert.equal(spawnCalls[0].cwd, '/e/yaogan-jingjiaozheng')
+  }
+})
+
+test('execute falls back to the session cwd when an explicit workdir is ENOENT (issue #55)', async () => {
+  const registered = []
+  const spawnCalls = []
+  const ctx = {
+    subprocess: {
+      async resolveExecutable(path) { return path },
+      spawn(options) {
+        spawnCalls.push(options)
+        if (options.cwd === 'D:/missing') {
+          return { done: Promise.reject(new Error('spawn C:\\Program Files\\Git\\bin\\bash.exe ENOENT')) }
+        }
+        return {
+          done: Promise.resolve({ exitCode: 0 }),
+          collected: {
+            stdout: { readFrom() { return { text: 'ok' } } },
+            stderr: { readFrom() { return { text: '' } } },
+          },
+        }
+      },
+    },
+    tools: { register(t) { registered.push(t) } },
+  }
+  apply(ctx)
+  const result = await registered[0].execute({ command: 'pwd', workdir: 'D:/missing' }, exec())
+  assert.equal(spawnCalls.length, 2)
+  assert.equal(spawnCalls[0].cwd, 'D:/missing')
+  assert.equal(spawnCalls[1].cwd, 'C:/work')
+  assert.match(result.text, /fell back to session cwd/)
+  assert.match(result.text, /ok/)
 })
 
 test('a non-zero exit throws with the captured output', async () => {

--- a/whoami-standard/custom-bash.mjs
+++ b/whoami-standard/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/wire-think-standard/custom-bash.mjs
+++ b/wire-think-standard/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.

--- a/zero-anchored-standard/custom-bash.mjs
+++ b/zero-anchored-standard/custom-bash.mjs
@@ -82,6 +82,23 @@ export function bashCandidates(env, gitExe) {
   return [...new Set(candidates)]
 }
 
+/**
+ * Git Bash / MSYS drive path (`/e/foo`) → Windows path (`E:\foo`).
+ * Unix paths like `/usr/bin` or `/tmp` are left unchanged. Exported for tests.
+ */
+export function normalizeGitBashWorkdir(workdir, platform = process.platform) {
+  if (typeof workdir !== 'string' || workdir.length === 0) return workdir
+  if (platform !== 'win32') return workdir
+  const match = workdir.match(/^\/([a-zA-Z])(?:\/(.*))?$/)
+  if (!match) return workdir
+  const rest = match[2] ? match[2].replace(/\//g, '\\') : ''
+  return rest ? `${match[1].toUpperCase()}:\\${rest}` : `${match[1].toUpperCase()}:\\`
+}
+
+function isWorkdirEnoent(error) {
+  return /\bENOENT\b/.test(String((error && error.message) || error || ''))
+}
+
 /** Tool parameter schema for the model-facing command. */
 const commandSchema = {
   type: 'object',
@@ -92,7 +109,7 @@ const commandSchema = {
     },
     workdir: {
       type: 'string',
-      description: 'Optional working directory; defaults to the session cwd.',
+      description: 'Optional working directory; defaults to the session cwd. On Windows, Git Bash paths like /e/foo are accepted and converted to E:\\foo.',
     },
   },
   required: ['command'],
@@ -160,6 +177,7 @@ export function apply(ctx, config) {
       "* To inspect a particular line range of a file, e.g. lines 10-25, try 'sed -n 10,25p /path/to/the/file'.",
       '* Please avoid commands that may produce a very large amount of output.',
       '* NOTE: runs without OS sandbox confinement on Windows (no landlock); treat output as untrusted.',
+      '* workdir accepts a Windows path or a Git Bash drive path (/e/foo).',
     ].join('\n'),
     parameters: commandSchema,
     output: {
@@ -175,13 +193,15 @@ export function apply(ctx, config) {
     },
     async execute(args, exec) {
       const shell = await resolveShell(exec?.signal)
-      const workdir = typeof args.workdir === 'string' && args.workdir.length > 0
+      const sessionCwd = exec?.agent?.session?.header?.cwd
+      const requested = typeof args.workdir === 'string' && args.workdir.length > 0
         ? args.workdir
-        : exec?.agent?.session?.header?.cwd
+        : sessionCwd
+      const workdir = normalizeGitBashWorkdir(requested)
       const signal = exec?.signal
-      const handle = ctx.subprocess.spawn({
+      const spawnOnce = (cwd) => ctx.subprocess.spawn({
         argv: [shell, '-c', args.command],
-        ...workdir !== undefined ? { cwd: workdir } : {},
+        ...cwd !== undefined ? { cwd } : {},
         stdio: {
           stdin: 'ignore',
           stdout: { maxBytes: maxOutputBytes },
@@ -190,13 +210,32 @@ export function apply(ctx, config) {
         ...signal !== undefined ? { signal } : {},
         graceMs: 3000,
       })
+      let handle
       let outcome
+      let usedFallback = false
       try {
+        handle = spawnOnce(workdir)
         outcome = await handle.done
       } catch (error) {
-        // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
-        // which the runtime turns into an isError result.
-        throw new Error(`bash spawn failed: ${String(error)}`)
+        const fallback = sessionCwd !== undefined ? normalizeGitBashWorkdir(sessionCwd) : undefined
+        if (
+          requested !== undefined
+          && fallback !== undefined
+          && fallback !== workdir
+          && isWorkdirEnoent(error)
+        ) {
+          usedFallback = true
+          try {
+            handle = spawnOnce(fallback)
+            outcome = await handle.done
+          } catch (retryError) {
+            throw new Error(`bash spawn failed: ${String(retryError)}`)
+          }
+        } else {
+          // A spawn-level failure (bad executable, EPERM) surfaces as a throw,
+          // which the runtime turns into an isError result.
+          throw new Error(`bash spawn failed: ${String(error)}`)
+        }
       }
       let stdout = ''
       let stderr = ''
@@ -206,8 +245,11 @@ export function apply(ctx, config) {
       } catch {
         // Collected readers may be unavailable on some backends; tolerate.
       }
+      const note = usedFallback
+        ? `[custom-bash] workdir ${requested} was unusable (ENOENT); fell back to session cwd\n`
+        : ''
       const text = [stdout, stderr].filter((part) => part.length > 0).join('\n')
-      const tail = text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`
+      const tail = note + (text.length > 0 ? text : `exit code: ${outcome.exitCode} (no output)`)
       if (outcome.exitCode !== 0) {
         // Non-zero exit is a reported failure, not a throw: the model sees the
         // command output plus the exit code.


### PR DESCRIPTION
## Summary

On Windows, `custom-bash` passed Git Bash workdirs like `/e/foo` straight to Node `spawn`. Node treats that as `E:\e\foo`, which does not exist, and the error text names `bash.exe` so it looks like the shell is missing.

## Changes

- Convert `/e/foo` to `E:\foo` on win32; leave Unix paths such as `/usr/bin` and `/tmp` unchanged
- If an explicit workdir is ENOENT and differs from the session cwd, retry with the session cwd and note the fallback
- Accept both path spellings in the tool description
- Same fix in every preset copy of `custom-bash.mjs`
- Regression tests in `test/custom-bash.test.mjs`

## Test plan

- [x] `node --test test/custom-bash.test.mjs` (18 passed)

Fixes #55

Made with [Cursor](https://cursor.com)