### PR TITLE
fix(prefab): 默认 preset 直接创建的会话不再跳过轨迹预填充

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,8 @@ repository is self-contained: the `zero-anchored-standard/`,
 `whoami-standard/`, `prefab/`, `eternal-minimal/`, `wire-think-standard/`, and
 `combo-anchored/` variants install the same way, alone or together, with no
 other directory required (see their sections below). `prefab/` automatically
-hydrates newly selected sessions; follow [`prefab/README.md`](./prefab/README.md).
+hydrates both sessions switched to it and sessions created with it as the
+default preset; follow [`prefab/README.md`](./prefab/README.md).
 
 PowerShell:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -302,7 +302,8 @@ Prefab 模式推荐由 AI agent 一键安装：把本仓库交给编程 agent，
 `anchored-standard`。仓库中的每个模式目录都是自包含的：`zero-anchored-standard/`、
 `whoami-standard/`、`prefab/`、`eternal-minimal/`、`wire-think-standard/`、
 `combo-anchored/` 变体以同样方式安装，可只装其中一个、多个或全部，不依赖
-其他目录（见下文各自的章节）。`prefab/` 选择模式时会自动预填充内置模板；
+其他目录（见下文各自的章节）。`prefab/` 会为手动切换到该模式的会话，以及创建时
+已将其作为默认 preset 的会话自动预填充内置模板；
 按 [`prefab/README.md`](./prefab/README.md) 操作。
 
 PowerShell：

--- a/prefab/README.md
+++ b/prefab/README.md
@@ -36,8 +36,10 @@ node .\prefab\install.mjs --confirm-dsh-closed --template project2
 
 This installs **Prefab Anchored Project2** as `prefab-anchored-project2`.
 
-Harness creates a blank session before mounting a selected preset. The bundled
-`prefab-session-seed.mjs` observes the committed preset selection, crosses the
+Harness can either mount this preset onto a blank session or create a session
+whose header already names it as the default preset. The bundled
+`prefab-session-seed.mjs` observes the committed preset selection in the first
+case and the first `permission/preset` event in the second, crosses the
 non-reentrant `Session.append` boundary with one microtask, and replays the two
 model-visible warm-up turns into that same session. It omits thousands of token
 stream chunks while retaining lifecycle events, messages, tool calls/results,
@@ -118,7 +120,8 @@ or profile can still be discovered and unlocked at runtime through
 - `template.jsonl`: the reviewed, bundled session template.
 - `template.jsonl.meta.json`: roll provenance and trajectory summary.
 - `templates/project2-benchmark.jsonl`: explicit opt-in benchmark template.
-- `prefab-session-seed.mjs`: automatic in-place hydration on mode selection.
+- `prefab-session-seed.mjs`: automatic in-place hydration on mode selection or
+  default-preset session creation.
 - `install.mjs`: one-command mode installation.
 - `instantiate.mjs`: legacy offline workspace-specific session instantiation.
 - `roll-runner.mjs` and `roll-prefab.mjs`: optional tooling for producing a

--- a/prefab/prefab-session-seed.mjs
+++ b/prefab/prefab-session-seed.mjs
@@ -492,7 +492,11 @@ export function apply(ctx, config = {}) {
             ? buildSeedPlan(template, cwd, agentsMd, skillResults)
             : preliminary
           if (seedSession(session, plan, title)) {
-            if (agent !== undefined) synchronizeAgentTurnCursor(agent, session)
+            // The default-preset path may publish its agent while the skill
+            // registry is being queried. Re-read after the await so an agent
+            // created in that window receives the seeded turn cursor.
+            const currentAgent = ctx.get('agents')?.get(session.id)
+            if (currentAgent !== undefined) synchronizeAgentTurnCursor(currentAgent, session)
           }
         } catch (error) {
           ctx.logger?.error?.(`${name}: failed to seed session ${session.id}: ${String(error?.stack ?? error)}`)

--- a/prefab/prefab-session-seed.mjs
+++ b/prefab/prefab-session-seed.mjs
@@ -452,7 +452,17 @@ export function apply(ctx, config = {}) {
   const scheduled = new WeakSet()
 
   ctx.on('session/event', (session, event) => {
-    if (event.type !== 'agent-preset/selected' || event.data?.agentPreset !== presetId) return
+    // Trigger on either of two lifecycle events:
+    // 1. `agent-preset/selected` — the preset picker swapped THIS preset onto
+    //    an already-created blank session (the original trigger).
+    // 2. A session CREATED with this preset in its header (the default preset
+    //    path) never emits `agent-preset/selected` — the preset is composed at
+    //    creation, not swapped. Its first `permission/preset` event therefore
+    //    doubles as the "this preset is live" signal: seed on it too, so
+    //    default-preset sessions start from turn 3 instead of turn 1.
+    const selected = event.type === 'agent-preset/selected' && event.data?.agentPreset === presetId
+    const born = event.type === 'permission/preset' && session.header?.agentPreset === presetId
+    if (!selected && !born) return
     if (scheduled.has(session) || session.events.some((item) => item.type === 'turn/start')) return
     scheduled.add(session)
 
@@ -470,7 +480,10 @@ export function apply(ctx, config = {}) {
           // ReactLoopAgent snapshots the final turn in its constructor. Preset
           // selection happens later, so validate that cursor before appending a
           // lifecycle transcript and synchronize it immediately afterwards.
-          synchronizeAgentTurnCursor(agent, session)
+          // The agent may not exist yet on the born path (creation is still
+          // assembling the session) — skip cursor sync until it does; the
+          // turn/start guard keeps a later double-seed from firing.
+          if (agent !== undefined) synchronizeAgentTurnCursor(agent, session)
           const cwd = session.header?.cwd
           const agentsMd = loadInstructionBundle(cwd)
           const preliminary = buildSeedPlan(template, cwd, agentsMd)
@@ -479,7 +492,7 @@ export function apply(ctx, config = {}) {
             ? buildSeedPlan(template, cwd, agentsMd, skillResults)
             : preliminary
           if (seedSession(session, plan, title)) {
-            synchronizeAgentTurnCursor(agent, session)
+            if (agent !== undefined) synchronizeAgentTurnCursor(agent, session)
           }
         } catch (error) {
           ctx.logger?.error?.(`${name}: failed to seed session ${session.id}: ${String(error?.stack ?? error)}`)

--- a/test/prefab-session-seed.test.mjs
+++ b/test/prefab-session-seed.test.mjs
@@ -169,6 +169,40 @@ test('session created with the preset as default seeds on its first permission e
   }
 })
 
+test('default-preset seeding synchronizes an agent published while skills are loading', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-prefab-born-race-'))
+  try {
+    const handlers = new Map()
+    let publishSkills
+    const skillsReady = new Promise((resolve) => { publishSkills = resolve })
+    let agent
+    const ctx = {
+      on(type, callback) { handlers.set(type, callback) },
+      get(service) {
+        if (service === 'agents') return { get() { return agent } }
+        if (service === 'skills') return { async list() { await skillsReady; return [] } }
+        return undefined
+      },
+      logger: { error(error) { throw new Error(error) } },
+    }
+    const session = fakeSession(dir)
+    session.header.agentPreset = 'prefab-anchored-standard'
+    apply(ctx, { templatePath: fixture(dir) })
+    session.listener = handlers.get('session/event')
+
+    session.append('permission/preset', { preset: 'workspace-write' })
+    await Promise.resolve()
+    agent = { session, status: 'idle', phase: { kind: 'idle', lastTurn: 0 } }
+    publishSkills()
+    await settle()
+
+    assert.equal(agent.phase.lastTurn, 1, 'late-published agent must see the seeded turn')
+    assert.equal(agent.phase.lastTurn + 1, 2)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('session with a different preset header ignores permission events', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'dsh-prefab-born-other-'))
   try {

--- a/test/prefab-session-seed.test.mjs
+++ b/test/prefab-session-seed.test.mjs
@@ -134,6 +134,62 @@ test('preset selection seeds after publication and ignores other or nonblank ses
   }
 })
 
+test('session created with the preset as default seeds on its first permission event', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-prefab-born-'))
+  try {
+    const handlers = new Map()
+    const errors = []
+    const ctx = {
+      on(type, callback) { handlers.set(type, callback) },
+      get(service) { return service === 'agents' ? this.agents : undefined },
+      logger: { error(message) { errors.push(message) } },
+    }
+    // A session CREATED with the preset: the header names it, and no
+    // agent-preset/selected event is ever emitted. The first
+    // permission/preset event must trigger seeding (agent may not exist yet).
+    const session = fakeSession(dir)
+    session.header.agentPreset = 'prefab-anchored-standard'
+    ctx.agents = { get(id) { return id === session.id ? undefined : undefined } }
+    apply(ctx, { templatePath: fixture(dir) })
+
+    session.listener = handlers.get('session/event')
+    session.append('permission/preset', { preset: 'workspace-write' })
+    await settle()
+    assert.equal(session.events.some((event) => event.type === 'turn/start'), true, 'born session must be seeded')
+    assert.equal(session.events.at(-1).data.title, 'Prefab Anchored Standard - Ready')
+    assert.deepEqual(errors, [], 'no agent on the born path must not error')
+
+    // The turn/start guard must prevent a later double-seed.
+    const countAfterFirst = session.events.filter((event) => event.type === 'turn/start').length
+    session.append('permission/preset', { preset: 'workspace-write' })
+    await settle()
+    assert.equal(session.events.filter((event) => event.type === 'turn/start').length, countAfterFirst, 'no double-seed')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('session with a different preset header ignores permission events', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-prefab-born-other-'))
+  try {
+    const handlers = new Map()
+    const ctx = {
+      on(type, callback) { handlers.set(type, callback) },
+      get() { return undefined },
+      logger: { error() {} },
+    }
+    const session = fakeSession(dir)
+    session.header.agentPreset = 'standard'
+    apply(ctx, { templatePath: fixture(dir) })
+    session.listener = handlers.get('session/event')
+    session.append('permission/preset', { preset: 'workspace-write' })
+    await settle()
+    assert.equal(session.events.some((event) => event.type === 'turn/start'), false, 'other preset must not seed')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('bundled two-turn template continues at turn three with a clean durable tool surface', () => {
   const template = loadPrefabTemplate()
   const plan = buildSeedPlan(template, 'D:\\workspace', '# current rules')


### PR DESCRIPTION
## 问题

当用户把本 preset 设为 DSH 默认模式时，新会话直接以该 preset 创建（会话 header 直接带 `agentPreset`），此时不会产生 `agent-preset/selected` 事件——该事件只在"先建空白会话、再手动切换模式"的路径上发出。

而 `prefab-session-seed` 此前只监听 `agent-preset/selected`，导致：
- 默认模式路径的新会话**永远不执行轨迹预填充**，首轮从 turn 1 开始而不是从预填充的 turn 3 开始，prefab 的核心价值（预置锚定轨迹）完全失效；
- 实测佐证：会话日志中既无 seed 事件，也出现 `session-title-llm: title output reached maxOutputTokens` 告警（首轮含推理内容被当作标题输入）。

## 修复

- 在现有 `agent-preset/selected` 触发之外，增加第二条触发路径：会话 header 已带本 preset 时，其首个 `permission/preset` 事件（会话创建流程的必然事件，在 preset 挂载之后落盘）同样触发 seeding，因此默认模式路径的新会话也能从 turn 3 开始。
- 修复竞态：默认 preset 路径可能在技能注册表查询期间发布 agent。seeding 完成前的 await 之后**重新读取** agent，使该窗口内发布的 agent 也能收到预填充的回合游标；原逻辑持有的是 await 前的引用，会漏掉它。
- 兼容 agent 尚未发布的情况：agent 缺失时跳过游标同步（原逻辑假定 agent 必在，会在该路径抛错），由既有的 `turn/start` 守卫防止重复 seed。
- 原有"手动切换模式"路径行为完全不变。

## 测试

- 新增 3 个用例：header 带 preset 的会话在首个 permission 事件后完成 seed 且不重复；header 带其它 preset 的会话不触发；技能加载期间发布 agent 的竞态用例。
- 本地全量测试套件 208/208 通过。

## 文档

- README.md / README.zh-CN.md / prefab/README.md 同步说明两种触发路径（手动切换 + 默认 preset 创建）。

## 备注

- 仓库处于维护模式，此改动仅修 bug、无破坏性变更，符合维护性更新定位。