### PR TITLE
fix(instruction-hint): unique per-injection id to survive the restart scan hole (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,18 @@ npm test
   installation.
 - The plugin performs no network requests and adds no telemetry.
 
+### Troubleshooting: a duplicate `instruction-hint` after a host restart
+
+`instruction-hint` injects its hint at most once per session via a durable scan of
+`session.events`. The scan is preventive, not guaranteed: if the first `agent/pre-step`
+after a host restart runs before the session log is materialized, the scan sees an empty
+event list and re-injects the hint. Older versions also used a deterministic id
+(`instruction-hint-<sessionId>`), so a re-injected duplicate collided with the original
+message and stopped history assembly. Since the unique-id change, a re-injection degrades
+to a few wasted context tokens instead. If an old log was broken by the deterministic-id
+collision, repairing it should dedup on `source.kind === 'instruction-hint'`, which still
+identifies the old rows (they share one id; new rows no longer do).
+
 ## Zero-Anchored Standard (experimental)
 
 An extra test mode that does not change the Anchored Standard logic above. It

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -376,6 +376,10 @@ npm test
 - preset 与 shell 访问具有相同信任等级，安装前应自行审阅文件；
 - 插件不会发起网络请求，也不增加遥测。
 
+### 排障：主机重启后重复注入的 `instruction-hint`
+
+`instruction-hint` 通过扫描 `session.events` 的持久事件，将提示控制在每个会话至多注入一条。该扫描是预防而非保证：若主机重启后的首个 `agent/pre-step` 在会话日志物化之前运行，扫描会看到空事件列表而再次注入。旧版本还使用确定性 id（`instruction-hint-<sessionId>`），重复注入与原始消息冲突会导致历史停止组装；改为唯一 id 后，重复注入只会浪费少量上下文 token。旧日志若曾因该冲突断裂，修复时应按 `source.kind === 'instruction-hint'` 去重（旧行共享同一 id；新行不再共享）。
+
 ## Zero-Anchored Standard（实验）
 
 这是不改变上面 Anchored Standard 逻辑的额外测试模式。它沿用同一套 Minimal

--- a/combo-anchored/instruction-hint.mjs
+++ b/combo-anchored/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/eternal-minimal/instruction-hint.mjs
+++ b/eternal-minimal/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/prefab/instruction-hint.mjs
+++ b/prefab/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/preset/instruction-hint.mjs
+++ b/preset/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/shared/instruction-hint.mjs
+++ b/shared/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/test/instruction-hint.test.mjs
+++ b/test/instruction-hint.test.mjs
@@ -69,8 +69,9 @@ test('after promotion ONE hint is injected once per session', async () => {
 
 test('a process restart does not re-inject: the guard is durable', async () => {
   // A fresh plugin instance (new process) over a session log that already
-  // carries one hint message — the same deterministic id twice would break
-  // history replay.
+  // carries one hint message. The durable scan is prevention; per-injection
+  // unique ids are the tolerance layer that would keep history replay alive
+  // even if the scan ran before the log was materialized.
   const { listeners } = register()
   const agent = { session: session([
     { type: 'assistant/message', seq: 1, data: {} },

--- a/whoami-standard/instruction-hint.mjs
+++ b/whoami-standard/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/wire-think-standard/instruction-hint.mjs
+++ b/wire-think-standard/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },

--- a/zero-anchored-standard/instruction-hint.mjs
+++ b/zero-anchored-standard/instruction-hint.mjs
@@ -16,12 +16,16 @@
  *      - project chain: AGENTS.md / CLAUDE.md / AGENTS.local.md / CLAUDE.local.md
  *        walking up from the session cwd to the project root (a directory
  *        containing `.git`, or the cwd itself).
- *  - The hint is ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the guard
- *    scans the session log for an existing `instruction-hint` message (then
- *    O(1)), so a process restart — whose in-memory state starts empty —
- *    cannot inject a second copy. A duplicate would collide with the first
- *    message's deterministic id (`instruction-hint-<sessionId>`) and break
- *    history replay.
+ *  - The hint is intended ONCE PER SESSION, DERIVED FROM DURABLE EVENTS: the
+ *    guard scans the session log for an existing `instruction-hint` message
+ *    (then O(1)), so a process restart — whose in-memory state starts empty —
+ *    cannot inject a second copy. The scan is prevention, not a guarantee: if
+ *    it runs before the session log is materialized after a host restart it
+ *    sees an empty event list and re-injects. Each message therefore also
+ *    carries a UNIQUE id (`instruction-hint-<sessionId>-<randomUUID>`), which
+ *    turns a past or future re-injection into a few wasted context tokens
+ *    instead of a broken history replay — the old deterministic id would
+ *    collide with the first copy and stop history assembly entirely.
  *  - The hint instructs the model to READ the files before acting when
  *    relevant, without embedding their content.
  *  - Files are probed via `ctx.fs` (the host filesystem seam); a missing fs
@@ -41,6 +45,7 @@
  * only while the session is unpromoted (never the intended path).
  */
 
+import { randomUUID } from 'node:crypto'
 import { createEpochPromotion } from './compaction-epoch.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -216,7 +221,7 @@ export function apply(ctx, config) {
       return {
         ...decision,
         messages: [...decision.messages, {
-          id: `instruction-hint-${session.id}`,
+          id: `instruction-hint-${session.id}-${randomUUID()}`,
           role: 'user',
           content: [{ type: 'text', text }],
           source: { kind: 'instruction-hint', form: 'hint' },


### PR DESCRIPTION
## What

`instruction-hint` now uses a per-injection unique id instead of the deterministic `instruction-hint-<sessionId>`:

```js
id: `instruction-hint-${session.id}-${randomUUID()}`,
```

applied to all materialized copies via `npm run sync`.

## Why (as discussed in #76)

The durable-scan dedup is prevention, not a guarantee — if the first `agent/pre-step` after a host restart runs before `session.events` is materialized, the scan sees an empty list and re-injects. Under the old deterministic id that duplicate collided with the first copy and **stopped history assembly entirely**. With unique ids, a past or future re-injection degrades to a few wasted context tokens instead.

The durable scan stays in place (prevention) and the unique id becomes the tolerance layer, exactly the combination described in the thread.

## Also

- README (en + zh) gains a short troubleshooting note: old broken logs should be deduped on `source.kind === 'instruction-hint'`, since old rows share one id and new rows no longer do.
- Updated the stale comment in `test/instruction-hint.test.mjs` that described the deterministic-id behavior.

## Verification

- `node scripts/sync-modes.mjs --check` — copies match shared sources
- `node --test` — 205/205 pass