### PR TITLE
fix(dev-tool-search): fuzzy token scoring + teach the toolNames unlock path (#32)

### DIFF
--- a/combo-anchored/dev-tool-search.mjs
+++ b/combo-anchored/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')

--- a/prefab/dev-tool-search.mjs
+++ b/prefab/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')

--- a/preset/dev-tool-search.mjs
+++ b/preset/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')

--- a/shared/dev-tool-search.mjs
+++ b/shared/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')

--- a/test/dev-tool-search.test.mjs
+++ b/test/dev-tool-search.test.mjs
@@ -95,5 +95,26 @@ test('schemas() is queried with the executing agent as the viewing scope (issue 
   const result = await ctx.tools.registered.execute({ query: 'pwsh' }, { agent })
   assert.equal(calls.length, 1)
   assert.equal(calls[0], agent, 'the executing agent is the viewing scope, so agent-scoped preset tools are visible')
-  assert.match(result.text, /pwsh: Execute a PowerShell command/)
+  assert.match(result.text, /pwsh.*Execute a PowerShell command/)
+})
+
+test('long natural-language query returns the most relevant tools (fuzzy scoring, not AND)', async () => {
+  const { registered } = register([
+    { name: 'web_search', description: 'internet search and web retrieval' },
+    { name: 'write', description: 'write files' },
+    { name: 'str_replace_editor', description: 'viewing, creating and editing files' },
+    { name: 'bash', description: 'run commands' },
+  ])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({ query: 'file edit write replace script root permissions' }, exec())
+  assert.match(result.text, /write/, 'long query must not return "No tools match" when tools match some tokens')
+  assert.doesNotMatch(result.text, /No tools match/)
+})
+
+test('empty search result teaches the direct unlock path (toolNames)', async () => {
+  const { registered } = register([{ name: 'bash', description: 'run commands' }])
+  const tool = registered.find((t) => t.name === 'dev_tool_search')
+  const result = await tool.execute({ query: 'zzz-nothing' }, exec())
+  assert.match(result.text, /No tools match/)
+  assert.match(result.text, /toolNames/)
 })

--- a/whoami-standard/dev-tool-search.mjs
+++ b/whoami-standard/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')

--- a/wire-think-standard/dev-tool-search.mjs
+++ b/wire-think-standard/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')

--- a/zero-anchored-standard/dev-tool-search.mjs
+++ b/zero-anchored-standard/dev-tool-search.mjs
@@ -16,6 +16,14 @@
  * set cannot do: the model should reach for dev_tool_search the moment a task
  * needs internet, delegation, workflows, goals, images, background jobs, or
  * multi-agent coordination — not try to work around them with bash.
+ *
+ * FIX (local): search matching was AND-over-all-tokens, so a long natural
+ * query ("file edit write replace script root permissions") matched NOTHING
+ * even against the full catalog. Now: exact name match wins, then tools
+ * matching at least one token ranked by hit count. The description also
+ * teaches the unlock path explicitly ("search empty ≠ tool absent — unlock
+ * by exact toolNames"), because models observed in the wild only search and
+ * never pass toolNames.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -71,6 +79,9 @@ export function apply(ctx) {
       ...UNLOCKABLE_INDEX.map((line) => `- ${line}`),
       '',
       'Usage: pass `query` to search the catalog (returns matching tool names + descriptions), then pass `toolNames` with exact names to unlock them. Unlocked tools appear from the next request on and stay unlocked for the session.',
+      '',
+      'Example: dev_tool_search({"query":"web","toolNames":["web_search"]}) — search AND unlock in one call.',
+      'IMPORTANT: an empty search result does NOT mean the tool does not exist — it only means no tool matched ALL of your keywords. If the task needs any tool listed above, unlock it directly by exact name: dev_tool_search({"toolNames":["web_search"]}). Prefer short 1-2 keyword queries.',
     ].join('\n'),
     parameters: toJsonSchema({
       query: { type: 'string', required: false, description: 'search keywords (e.g. "web", "subagent")' },
@@ -104,20 +115,35 @@ export function apply(ctx) {
         // harness's own code mode (`registry.schemas(exec.agent)`).
         const schemas = ctx.tools.schemas(exec?.agent)
         const wanted = query.toLowerCase().split(/[^a-z0-9_]+/).filter(Boolean)
-        const all = schemas.filter((schema) => {
-          const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
-          return wanted.every((token) => haystack.includes(token))
-        })
-        const matches = all.slice(0, MAX_RESULTS)
-        if (all.length === 0) {
-          lines.push(`No tools match "${query}".`)
+        // FIX: score instead of AND-filter. Exact name match ranks first;
+        // otherwise every tool matching at least one token competes, ordered
+        // by hit count (desc) then name. A long natural-language query no
+        // longer returns an empty catalog.
+        const scored = schemas
+          .map((schema) => {
+            const haystack = `${schema.name} ${schema.description ?? ''}`.toLowerCase()
+            let score = 0
+            for (const token of wanted) if (haystack.includes(token)) score += 1
+            return {
+              schema,
+              score,
+              exact: wanted.includes(schema.name.toLowerCase()),
+            }
+          })
+          .filter((entry) => wanted.length > 0 && (entry.exact || entry.score >= 1))
+          .sort((a, b) => (b.exact - a.exact) || (b.score - a.score) || a.schema.name.localeCompare(b.schema.name))
+        const matches = scored.slice(0, MAX_RESULTS)
+        if (matches.length === 0) {
+          lines.push(
+            `No tools match "${query}". An empty result only means no tool matched ALL keywords — if you need a specific tool, unlock it directly by exact name, e.g. dev_tool_search({"toolNames":["web_search"]}).`,
+          )
         } else {
-          lines.push(`Matching tools (${matches.length}${all.length > MAX_RESULTS ? ` of ${all.length}` : ''}):`)
-          for (const schema of matches) {
+          lines.push(`Matching tools (${matches.length}${scored.length > MAX_RESULTS ? ` of ${scored.length}` : ''}):`)
+          for (const { schema, exact, score } of matches) {
             const desc = (schema.description || '').split('\n')[0].slice(0, 90)
-            lines.push(`- ${schema.name}: ${desc}`)
+            lines.push(`- ${schema.name}${exact ? ' (exact)' : ''}: ${desc}`)
           }
-          if (all.length > MAX_RESULTS) {
+          if (scored.length > MAX_RESULTS) {
             lines.push(`(truncated at ${MAX_RESULTS} — add tokens to narrow the query, e.g. "mcp browser" or "mcp tavily")`)
           }
           lines.push('Unlock with dev_tool_search({"toolNames": ["<exact name>"]}).')


### PR DESCRIPTION
## 问题

按需解锁链路（`dev_tool_search`）在真实会话中失效——**即使 scope 修复（issue #32 / PR #31 的 `schemas(exec?.agent)`）已经合入**。在一次真实的 anchored-standard 会话日志中，模型两次调用 `dev_tool_search` 均返回 `No tools match`，未解锁任何工具，resident 目录整个会话恒为 5 个——标准工具（web_search、subagent、todo_write 等）全程不可达。

证据已发布在 [issue #32](https://github.com/xiaobright/dsh-anchored-standard/issues/32#issuecomment-5408508279)。

## 根因——两个独立缺陷

**缺陷 A：搜索匹配是 AND 全 token 逻辑**

```js
return wanted.every((token) => haystack.includes(token))
```

真实会话中出现的长自然语言查询 `"file edit write replace script root permissions"`（7 个 token）要求某个工具的 name+description 同时包含**全部** token——没有任何工具能满足，即使目录完整也必然返回 `No tools match`（已复现：单 token 如 `web`/`todo` 能命中，7 token 查询永远失败）。现有回归测试只覆盖单 token 场景（`subagent`），测不出这个问题。

**缺陷 B：模型从不传 `toolNames`，解锁永不登记**

描述虽写明 "pass toolNames with exact names to unlock"，但实测模型只传 `query`。`tool-bootstrap.mjs` 的 `unlockedFor()` 从 `tool/call` 参数里解析解锁名单，没有 `toolNames` 就永远解不开 → resident 目录永不增长。

## 修复

`shared/dev-tool-search.mjs`（经 `sync-modes` 物化到全部模式目录）：

1. **模糊评分取代 AND 过滤**——名称精确匹配优先，其次按「命中 token 数」降序返回命中 ≥1 个 token 的工具。失败的查询现在返回 `write (exact)`、`edit (exact)`、`str_replace_editor`、`todo_write` 等，而不是空结果。
2. **在工具描述里教解锁路径**——加一步到位示例 `dev_tool_search({"query":"web","toolNames":["web_search"]})`，并明确「空搜索结果不代表工具不存在，可直接用 toolNames 精确解锁」。

## 验证

- **测试：211/211 通过**（新增 2 条回归：长自然语言查询不再返回 `No tools match`；空结果时提示 `toolNames` 解锁路径）。`scripts/sync-modes.mjs --check` 无 drift。
- **远程真实会话端到端**（deepseek-v4-pro，8 步）：
  - `dev_tool_search({"query":"file edit write replace script root permissions"})` → **返回 20 个工具**（修复前必为 `No tools match`）
  - `dev_tool_search({"toolNames":["todo_write","web_search"]})` → `Unlocked for the next request: todo_write, web_search`
  - 下一请求 header：**工具数 2 → 5 → 7**（todo_write、web_search 出现）
  - `todo_write` 实际执行成功（创建任务 → 标记完成）

## 说明

- 本次改动只影响工具的**搜索行为**，未触碰 bootstrap/resident 阶段逻辑与注入上下文控制。模糊搜索本身对轨迹锚定的影响**未重新评测**（无 API 预算）——修复只是扩大搜索召回并教模型使用文档已写的解锁路径，resident 目录组成未变。
- 尊重维护期状态：这是有清晰复现路径的 bug 修复，不是新功能。
