### PR TITLE
docs: document identity drift under the bare Minimal persona

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,18 @@ npm test
 - The preset has the same trust level as shell access. Review its files before
   installation.
 - The plugin performs no network requests and adds no telemetry.
+- The Minimal persona is intentionally bare (`You are a helpful software
+  engineer assistant.`, `complete: true`) — the byte-pure condition the anchor
+  was measured under. A side effect: the model has no identity anchor and may
+  fall back to training priors on identity questions (observed:
+  `deepseek-v4-pro` answering "I am Claude" when asked who it is; see
+  [#81](https://github.com/xiaobright/dsh-anchored-standard/issues/81)). To pin
+  identity without touching the tool schema, append the official identity line
+  to the persona `text:` —
+  `You are a helpful software engineer assistant. You are an AI agent powered by DeepSeek Harness.`
+  — then recreate the session. This deviates from the measured condition, so
+  verify your own first-round trajectory if exact anchoring matters (see
+  [#49](https://github.com/xiaobright/dsh-anchored-standard/issues/49)).
 
 ### Troubleshooting: a duplicate `instruction-hint` after a host restart
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -376,6 +376,15 @@ npm test
   连续性在这些点上断开；
 - preset 与 shell 访问具有相同信任等级，安装前应自行审阅文件；
 - 插件不会发起网络请求，也不增加遥测。
+- Minimal persona 有意保持极简（`You are a helpful software engineer assistant.`，
+  `complete: true`）——锚定所测量的逐字节纯净条件。副作用：模型没有身份锚定，在
+  身份类问题上可能回落到训练先验（实测 `deepseek-v4-pro` 被问"你是谁？"时自称
+  "I am Claude"；见
+  [#81](https://github.com/xiaobright/dsh-anchored-standard/issues/81)）。
+  如需固定身份而不改动工具 schema，在 persona 的 `text:` 后追加官方身份句——
+  `You are a helpful software engineer assistant. You are an AI agent powered by DeepSeek Harness.`
+  ——并重建会话。这会偏离被测条件，若在意精确锚定请自行验证首轮轨迹（参见
+  [#49](https://github.com/xiaobright/dsh-anchored-standard/issues/49)）。
 
 ### 排障：主机重启后重复注入的 `instruction-hint`
 


### PR DESCRIPTION
## What

Documents a reproducible side effect of the deliberately bare Minimal persona: the model has no identity anchor and falls back to training priors on identity questions (observed: `deepseek-v4-pro` answering "I am Claude" when asked "你是谁？").

Adds one bullet to **Important behavior** (and its zh-CN mirror **重要行为**) with a one-line recipe that pins identity without touching the tool schema — the decisive anchor lever.

## Why docs-only

- No defaults, no code, no behavior change: the persona stays byte-identical to Minimal, exactly as the mechanism requires.
- Per the project's evidence bar for prompt-text changes (#49 / #63), changing the default text would need a trajectory-level A/B, which is not included here.
- Full reproduction data and the fix verification live in #81.

## Verification performed (for the issue)

- DeepSeek Harness 0.1.1-rc.2, Windows 11, `deepseek-v4-pro`, `reasoningEffort: max`.
- Before the one-line fix: identity question answered *"我是 Claude，Anthropic 开发的 AI 编程助手…"*.
- After appending `You are an AI agent powered by DeepSeek Harness.` to the persona `text:`: same question answered *"我是 DeepSeek，由深度求索公司创造的 AI 助手…"*.
- Mechanical anchor checks unchanged on both sides: first `request/header` tools `[bash, str_replace_editor]`, no skill-catalog / AGENTS.md injection, promotion to the resident catalog, single runtime-context snapshot diffed in after promotion.

## Related

- #81 — [Behavior] Identity drift: model claims "I am Claude" under the bare Minimal persona
- #49 / #63 — trajectory-evidence precedent for prompt-text changes
