### PR TITLE
feat(wire-think): add orcarouter as a named think-route gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ whether subagents also take the anchor turn.
 | Key | Default | Meaning |
 |---|---|---|
 | `provider` | `deepseek-wire-think` | The sibling route id the adapter owns; registering an id twice throws DUPLICATE_ADAPTER (caught, degraded). |
+| `gateway` | *(none)* | Route the think condition at a named OpenAI-compatible gateway instead of the DeepSeek endpoint. `orcarouter` targets the OrcaRouter gateway (`https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY`) with a `vendor/model` model namespace (`deepseek/deepseek-chat`, `deepseek/deepseek-reasoner`, or the adaptive `orcarouter/auto` router). An unknown name fails the mount. |
 | `toolChoice` | `none` | The wire `tool_choice` sent whenever tool definitions are present. |
-| `baseURL` / `apiKeyEnv` | settings/env | Row config first, then the `llm-deepseek` settings section, then `DEEPSEEK_BASE_URL` / `DEEPSEEK_API_KEY`. |
+| `baseURL` / `apiKeyEnv` | settings/env | Row config first, then the `llm-deepseek` settings section, then `DEEPSEEK_BASE_URL` / `DEEPSEEK_API_KEY`. With `gateway` set, the gateway's endpoint/key env are the defaults and row config still wins. |
 | `logprobs` | `false` | Opt-in research hook: request token logprobs and log a per-request mean summary (no StreamChunk surface exists). |
 
 `wire-think` (in `wire-think-standard/`): same `mode` / `suppressedContextSources` /

--- a/shared/toolchoice-adapter.mjs
+++ b/shared/toolchoice-adapter.mjs
@@ -38,6 +38,17 @@
  * Registering the same provider id twice (two presets both mounting this row)
  * throws DUPLICATE_ADAPTER at mount; the plugin catches that, warns once,
  * and leaves the engine to degrade to the zero-tool think condition.
+ *
+ * Named gateway support: the same vendored wire pipeline can point at a
+ * named OpenAI-compatible gateway instead of the DeepSeek endpoint. Setting
+ * `gateway: "orcarouter"` routes this adapter at the OrcaRouter gateway
+ * (https://api.orcarouter.ai/v1) with the `ORCAROUTER_API_KEY` env var and
+ * the `vendor/model` model namespace (e.g. `deepseek/deepseek-chat`, or the
+ * adaptive `orcarouter/auto` router), so the think-route condition reproduces
+ * over a gateway that adds adaptive routing, automatic failover, zero-markup
+ * inference, observability, and guardrails on the same endpoint. Row config
+ * still wins: an explicit `baseURL` / `apiKeyEnv` overrides the gateway
+ * defaults. The DeepSeek default is untouched when `gateway` is unset.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -55,21 +66,50 @@ const DEFAULT_BASE_URL = 'https://api.deepseek.com'
 /** The terminal SSE sentinel (DeepSeek and OpenAI both send it). */
 const DONE = '[DONE]'
 
+/**
+ * Named OpenAI-compatible gateways this adapter can route at. Each entry
+ * pins the endpoint, the key env var, the provider label, and the advisory
+ * model namespace. Row config (`baseURL` / `apiKeyEnv`) still wins over
+ * these defaults.
+ */
+const GATEWAYS = {
+  orcarouter: {
+    baseURL: 'https://api.orcarouter.ai/v1',
+    apiKeyEnv: 'ORCAROUTER_API_KEY',
+    providerName: 'OrcaRouter (community think route)',
+    userAgent: 'orcarouter-harness-community-think-route-adapter/0.1.0 (dsh-plugin)',
+    catalogModels: ['deepseek/deepseek-chat', 'deepseek/deepseek-reasoner', 'orcarouter/auto'],
+  },
+}
+
 /** Advisory models — identical wire ids to the official catalog defaults. */
 const CATALOG_MODELS = ['deepseek-v4-pro', 'deepseek-v4-flash']
+
+/** Resolve the advisory catalog for the active gateway (default DeepSeek). */
+function catalogModels(gateway) {
+  return gateway?.catalogModels ?? CATALOG_MODELS
+}
 
 function nonEmptyString(value) {
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 /**
- * Resolve one operation's connection facts: row config > `llm-deepseek`
- * settings section > environment. Re-read per request so a settings change
- * reaches the next call without re-registration.
+ * Resolve one operation's connection facts. With a named gateway the
+ * endpoint and key env are pinned by the gateway entry (row config still
+ * wins); otherwise the DeepSeek fallback chain applies: row config >
+ * `llm-deepseek` settings section > environment. Re-read per request so a
+ * settings change reaches the next call without re-registration.
  */
-function resolveConnection(ctx, config) {
+function resolveConnection(ctx, config, gateway) {
   let baseURL = nonEmptyString(config?.baseURL)
   let apiKeyEnv = nonEmptyString(config?.apiKeyEnv)
+  if (gateway !== undefined) {
+    // A named gateway pins its endpoint and key env; row config still wins.
+    baseURL ??= gateway.baseURL
+    apiKeyEnv ??= gateway.apiKeyEnv
+    return { baseURL: baseURL.replace(/\/+$/, ''), apiKeyEnv }
+  }
   if (baseURL === undefined || apiKeyEnv === undefined) {
     try {
       const described = ctx.get('settings')?.describe?.() ?? []
@@ -85,6 +125,19 @@ function resolveConnection(ctx, config) {
   baseURL ??= nonEmptyString(process.env.DEEPSEEK_BASE_URL) ?? DEFAULT_BASE_URL
   apiKeyEnv ??= 'DEEPSEEK_API_KEY'
   return { baseURL: baseURL.replace(/\/+$/, ''), apiKeyEnv }
+}
+
+/**
+ * Resolve the named gateway entry; an unknown name is a config error (fail
+ * the mount loudly, never silently fall back to the DeepSeek default).
+ */
+function parseGateway(value) {
+  if (value === undefined) return undefined
+  const gateway = GATEWAYS[value]
+  if (gateway === undefined) {
+    throw new TypeError(`${name}: gateway must be one of ${Object.keys(GATEWAYS).join(', ')}, got ${JSON.stringify(value)}`)
+  }
+  return gateway
 }
 
 /** Resolve the bearer token: credentials service first, trusted env second. */
@@ -415,10 +468,18 @@ export async function* translateChunks(payloads, onLogprobs) {
   throw error
 }
 
-/** Register the sibling `tool_choice`-capable DeepSeek route. */
+/**
+ * Register the sibling `tool_choice`-capable route — the DeepSeek think
+ * route by default, or a named OpenAI-compatible gateway (`gateway:
+ * "orcarouter"`).
+ */
 export function apply(ctx, config) {
   const provider = nonEmptyString(config?.provider) ?? DEFAULT_PROVIDER
+  const gateway = parseGateway(config?.gateway)
   const logprobs = config?.logprobs === true
+  const providerName = gateway?.providerName ?? 'DeepSeek (community think route)'
+  const models = catalogModels(gateway)
+  const userAgent = gateway?.userAgent ?? 'deepseek-harness-community-think-route-adapter/0.1.0 (dsh-plugin)'
 
   let warned = false
   const warnOnce = (message) => {
@@ -433,13 +494,13 @@ export function apply(ctx, config) {
 
   const adapter = {
     providerInfo(id) {
-      return { id, name: 'DeepSeek (community think route)' }
+      return { id, name: providerName }
     },
     providerRetryPolicy() {
       return undefined
     },
     async listModels(id) {
-      return CATALOG_MODELS.map((model) => ({
+      return models.map((model) => ({
         provider: id,
         id: model,
         name: model,
@@ -465,14 +526,14 @@ export function apply(ctx, config) {
       }
     },
     async * stream(options) {
-      const connection = resolveConnection(ctx, config)
+      const connection = resolveConnection(ctx, config, gateway)
       const apiKey = await resolveApiKey(ctx, connection.apiKeyEnv)
       const body = serializeThinkRequest(options, { toolChoice: config?.toolChoice, logprobs })
       const headers = {
         authorization: `Bearer ${apiKey}`,
         'content-type': 'application/json',
         accept: 'text/event-stream',
-        'user-agent': 'deepseek-harness-community-think-route-adapter/0.1.0 (dsh-plugin)',
+        'user-agent': userAgent,
         ...(options.sessionId !== undefined ? { 'x-deepseek-harness-session-id': String(options.sessionId) } : {}),
         ...(options.purpose === 'compaction' ? { 'x-deepseek-harness-compact': '1' } : {}),
       }

--- a/test/toolchoice-adapter.test.mjs
+++ b/test/toolchoice-adapter.test.mjs
@@ -248,3 +248,70 @@ test('a missing API key fails with MISSING_CREDENTIAL before any fetch', async (
     if (savedKey !== undefined) process.env.DEEPSEEK_API_KEY = savedKey
   }
 })
+
+test('an unknown gateway name fails the mount loudly', () => {
+  assert.throws(
+    () => registerAdapterCtx({ gateway: 'not-a-gateway' }),
+    (error) => error instanceof TypeError && /orcarouter/.test(error.message),
+  )
+})
+
+test('gateway orcarouter pins the endpoint, key env, catalog, and provider label', async () => {
+  const { registration } = registerAdapterCtx({ gateway: 'orcarouter' })
+  assert.equal(registration.adapter.providerInfo('deepseek-wire-think').name, 'OrcaRouter (community think route)')
+  const models = await registration.adapter.listModels('deepseek-wire-think')
+  assert.deepEqual(models.map((model) => model.id), ['deepseek/deepseek-chat', 'deepseek/deepseek-reasoner', 'orcarouter/auto'])
+  const resolved = await registration.adapter.resolveModel('deepseek-wire-think', 'orcarouter/auto')
+  assert.equal(resolved.context.contextWindow, 1_000_000)
+})
+
+test('gateway orcarouter streams a think response over the OrcaRouter endpoint', async () => {
+  const savedKey = process.env.ORCAROUTER_API_KEY
+  process.env.ORCAROUTER_API_KEY = 'test-key'
+  const { registration } = registerAdapterCtx({ gateway: 'orcarouter', logprobs: false })
+  const bodies = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (url, init) => {
+    bodies.push({ url, init })
+    return new Response(sseStream([
+      'data: {"choices":[{"delta":{"content":"Plan ready"}}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":8,"completion_tokens":4}}\n\n',
+      'data: [DONE]\n\n',
+    ]), { status: 200, headers: { 'content-type': 'text/event-stream' } })
+  }
+  try {
+    const chunks = []
+    for await (const chunk of registration.adapter.stream({ ...OPTIONS(), model: 'orcarouter/auto' })) chunks.push(chunk)
+    assert.equal(bodies[0].url, 'https://api.orcarouter.ai/v1/chat/completions')
+    assert.equal(bodies[0].init.headers.authorization, 'Bearer test-key')
+    const sentBody = JSON.parse(bodies[0].init.body)
+    assert.equal(sentBody.model, 'orcarouter/auto')
+    assert.equal(sentBody.tool_choice, 'none')
+    const textDeltas = chunks.filter((chunk) => chunk.type === 'text-delta').map((chunk) => chunk.text).join('')
+    assert.equal(textDeltas, 'Plan ready')
+  } finally {
+    globalThis.fetch = originalFetch
+    if (savedKey === undefined) delete process.env.ORCAROUTER_API_KEY
+    else process.env.ORCAROUTER_API_KEY = savedKey
+  }
+})
+
+test('gateway orcarouter lets explicit row config override the pinned defaults', async () => {
+  process.env.ORCAROUTER_API_KEY = 'test-key'
+  const { registration } = registerAdapterCtx({ gateway: 'orcarouter', baseURL: 'https://example.test', apiKeyEnv: 'ORCAROUTER_API_KEY' })
+  const originalFetch = globalThis.fetch
+  const urls = []
+  globalThis.fetch = async (url, init) => {
+    urls.push(url)
+    return new Response(sseStream(['data: [DONE]\n\n']), { status: 200 })
+  }
+  try {
+    const chunks = []
+    for await (const chunk of registration.adapter.stream(OPTIONS())) chunks.push(chunk)
+    assert.ok(chunks.some((chunk) => chunk.type === 'finish'))
+    assert.equal(urls[0], 'https://example.test/chat/completions')
+  } finally {
+    globalThis.fetch = originalFetch
+    delete process.env.ORCAROUTER_API_KEY
+  }
+})

--- a/wire-think-standard/agent.cordis.yml
+++ b/wire-think-standard/agent.cordis.yml
@@ -34,7 +34,9 @@
 # degrades to the zero-tool think condition. MUST stay the FIRST local row so
 # the route exists before the engine's first probe. Set `logprobs: true` for
 # the opt-in logprobs research hook (mean token logprob per think request,
-# logged by the adapter).
+# logged by the adapter). Set `gateway: orcarouter` to route the same think
+# condition at the OrcaRouter gateway (OpenAI-compatible endpoint, vendor/model
+# model namespace incl. the adaptive `orcarouter/auto` router, ORCAROUTER_API_KEY).
 - id: toolchoice-adapter
   name: ./toolchoice-adapter.mjs
 

--- a/wire-think-standard/toolchoice-adapter.mjs
+++ b/wire-think-standard/toolchoice-adapter.mjs
@@ -38,6 +38,17 @@
  * Registering the same provider id twice (two presets both mounting this row)
  * throws DUPLICATE_ADAPTER at mount; the plugin catches that, warns once,
  * and leaves the engine to degrade to the zero-tool think condition.
+ *
+ * Named gateway support: the same vendored wire pipeline can point at a
+ * named OpenAI-compatible gateway instead of the DeepSeek endpoint. Setting
+ * `gateway: "orcarouter"` routes this adapter at the OrcaRouter gateway
+ * (https://api.orcarouter.ai/v1) with the `ORCAROUTER_API_KEY` env var and
+ * the `vendor/model` model namespace (e.g. `deepseek/deepseek-chat`, or the
+ * adaptive `orcarouter/auto` router), so the think-route condition reproduces
+ * over a gateway that adds adaptive routing, automatic failover, zero-markup
+ * inference, observability, and guardrails on the same endpoint. Row config
+ * still wins: an explicit `baseURL` / `apiKeyEnv` overrides the gateway
+ * defaults. The DeepSeek default is untouched when `gateway` is unset.
  */
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -55,21 +66,50 @@ const DEFAULT_BASE_URL = 'https://api.deepseek.com'
 /** The terminal SSE sentinel (DeepSeek and OpenAI both send it). */
 const DONE = '[DONE]'
 
+/**
+ * Named OpenAI-compatible gateways this adapter can route at. Each entry
+ * pins the endpoint, the key env var, the provider label, and the advisory
+ * model namespace. Row config (`baseURL` / `apiKeyEnv`) still wins over
+ * these defaults.
+ */
+const GATEWAYS = {
+  orcarouter: {
+    baseURL: 'https://api.orcarouter.ai/v1',
+    apiKeyEnv: 'ORCAROUTER_API_KEY',
+    providerName: 'OrcaRouter (community think route)',
+    userAgent: 'orcarouter-harness-community-think-route-adapter/0.1.0 (dsh-plugin)',
+    catalogModels: ['deepseek/deepseek-chat', 'deepseek/deepseek-reasoner', 'orcarouter/auto'],
+  },
+}
+
 /** Advisory models — identical wire ids to the official catalog defaults. */
 const CATALOG_MODELS = ['deepseek-v4-pro', 'deepseek-v4-flash']
+
+/** Resolve the advisory catalog for the active gateway (default DeepSeek). */
+function catalogModels(gateway) {
+  return gateway?.catalogModels ?? CATALOG_MODELS
+}
 
 function nonEmptyString(value) {
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
 /**
- * Resolve one operation's connection facts: row config > `llm-deepseek`
- * settings section > environment. Re-read per request so a settings change
- * reaches the next call without re-registration.
+ * Resolve one operation's connection facts. With a named gateway the
+ * endpoint and key env are pinned by the gateway entry (row config still
+ * wins); otherwise the DeepSeek fallback chain applies: row config >
+ * `llm-deepseek` settings section > environment. Re-read per request so a
+ * settings change reaches the next call without re-registration.
  */
-function resolveConnection(ctx, config) {
+function resolveConnection(ctx, config, gateway) {
   let baseURL = nonEmptyString(config?.baseURL)
   let apiKeyEnv = nonEmptyString(config?.apiKeyEnv)
+  if (gateway !== undefined) {
+    // A named gateway pins its endpoint and key env; row config still wins.
+    baseURL ??= gateway.baseURL
+    apiKeyEnv ??= gateway.apiKeyEnv
+    return { baseURL: baseURL.replace(/\/+$/, ''), apiKeyEnv }
+  }
   if (baseURL === undefined || apiKeyEnv === undefined) {
     try {
       const described = ctx.get('settings')?.describe?.() ?? []
@@ -85,6 +125,19 @@ function resolveConnection(ctx, config) {
   baseURL ??= nonEmptyString(process.env.DEEPSEEK_BASE_URL) ?? DEFAULT_BASE_URL
   apiKeyEnv ??= 'DEEPSEEK_API_KEY'
   return { baseURL: baseURL.replace(/\/+$/, ''), apiKeyEnv }
+}
+
+/**
+ * Resolve the named gateway entry; an unknown name is a config error (fail
+ * the mount loudly, never silently fall back to the DeepSeek default).
+ */
+function parseGateway(value) {
+  if (value === undefined) return undefined
+  const gateway = GATEWAYS[value]
+  if (gateway === undefined) {
+    throw new TypeError(`${name}: gateway must be one of ${Object.keys(GATEWAYS).join(', ')}, got ${JSON.stringify(value)}`)
+  }
+  return gateway
 }
 
 /** Resolve the bearer token: credentials service first, trusted env second. */
@@ -415,10 +468,18 @@ export async function* translateChunks(payloads, onLogprobs) {
   throw error
 }
 
-/** Register the sibling `tool_choice`-capable DeepSeek route. */
+/**
+ * Register the sibling `tool_choice`-capable route — the DeepSeek think
+ * route by default, or a named OpenAI-compatible gateway (`gateway:
+ * "orcarouter"`).
+ */
 export function apply(ctx, config) {
   const provider = nonEmptyString(config?.provider) ?? DEFAULT_PROVIDER
+  const gateway = parseGateway(config?.gateway)
   const logprobs = config?.logprobs === true
+  const providerName = gateway?.providerName ?? 'DeepSeek (community think route)'
+  const models = catalogModels(gateway)
+  const userAgent = gateway?.userAgent ?? 'deepseek-harness-community-think-route-adapter/0.1.0 (dsh-plugin)'
 
   let warned = false
   const warnOnce = (message) => {
@@ -433,13 +494,13 @@ export function apply(ctx, config) {
 
   const adapter = {
     providerInfo(id) {
-      return { id, name: 'DeepSeek (community think route)' }
+      return { id, name: providerName }
     },
     providerRetryPolicy() {
       return undefined
     },
     async listModels(id) {
-      return CATALOG_MODELS.map((model) => ({
+      return models.map((model) => ({
         provider: id,
         id: model,
         name: model,
@@ -465,14 +526,14 @@ export function apply(ctx, config) {
       }
     },
     async * stream(options) {
-      const connection = resolveConnection(ctx, config)
+      const connection = resolveConnection(ctx, config, gateway)
       const apiKey = await resolveApiKey(ctx, connection.apiKeyEnv)
       const body = serializeThinkRequest(options, { toolChoice: config?.toolChoice, logprobs })
       const headers = {
         authorization: `Bearer ${apiKey}`,
         'content-type': 'application/json',
         accept: 'text/event-stream',
-        'user-agent': 'deepseek-harness-community-think-route-adapter/0.1.0 (dsh-plugin)',
+        'user-agent': userAgent,
         ...(options.sessionId !== undefined ? { 'x-deepseek-harness-session-id': String(options.sessionId) } : {}),
         ...(options.purpose === 'compaction' ? { 'x-deepseek-harness-compact': '1' } : {}),
       }


### PR DESCRIPTION
This lets the Wire Think-Execute preset's think-route condition run over the OrcaRouter gateway instead of only the DeepSeek endpoint — the same `tool_choice: none` wire lever, but with access to the `vendor/model` model namespace (including the adaptive `orcarouter/auto` router) and no custom base URL needed.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. Given the project's own status note on DeepSeek API price increases, a zero-markup gateway route is a natural fit for keeping the evaluation loops affordable.

This mirrors the existing `toolchoice-adapter` sibling-route pattern (`deepseek-wire-think`) exactly: set `gateway: orcarouter` on the row and the adapter registers the same think route against `https://api.orcarouter.ai/v1`, resolving the key from `ORCAROUTER_API_KEY` with `baseURL`/`apiKeyEnv` row config still winning, and swaps the advisory catalog to `deepseek/deepseek-chat`, `deepseek/deepseek-reasoner`, and `orcarouter/auto`. An unknown gateway name fails the mount loudly rather than silently falling back to DeepSeek. The DeepSeek default is untouched when `gateway` is unset.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Changes: `shared/toolchoice-adapter.mjs` (+ its materialized `wire-think-standard/` copy) gains the `GATEWAYS` registry and gateway-aware connection/catalog resolution; `README.md` and the `agent.cordis.yml` row document the new option; `test/toolchoice-adapter.test.mjs` adds coverage for the gateway registration, catalog, streaming path, and config override. All 28 adapter/wire-think tests pass, and a live streaming completion through the gateway returned a real `stop`-terminated response.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
