### PR TITLE
feat: align subagent delegation config with dsh 0.1.2-alpha.3

### DIFF
--- a/combo-anchored/agent.cordis.yml
+++ b/combo-anchored/agent.cordis.yml
@@ -309,6 +309,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -327,7 +328,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -336,7 +337,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/combo-anchored/dev-tool-search.mjs
+++ b/combo-anchored/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',

--- a/eternal-minimal/agent.cordis.yml
+++ b/eternal-minimal/agent.cordis.yml
@@ -227,6 +227,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -245,7 +246,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -254,7 +255,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/prefab/agent.cordis.yml
+++ b/prefab/agent.cordis.yml
@@ -372,6 +372,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -390,7 +391,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -399,7 +400,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/prefab/dev-tool-search.mjs
+++ b/prefab/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -377,6 +377,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -395,7 +396,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -404,7 +405,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/preset/dev-tool-search.mjs
+++ b/preset/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',

--- a/shared/dev-tool-search.mjs
+++ b/shared/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',

--- a/whoami-standard/agent.cordis.yml
+++ b/whoami-standard/agent.cordis.yml
@@ -306,6 +306,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -324,7 +325,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -333,7 +334,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/whoami-standard/dev-tool-search.mjs
+++ b/whoami-standard/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',

--- a/wire-think-standard/agent.cordis.yml
+++ b/wire-think-standard/agent.cordis.yml
@@ -273,6 +273,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -291,7 +292,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -300,7 +301,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/wire-think-standard/dev-tool-search.mjs
+++ b/wire-think-standard/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -295,6 +295,7 @@
       config:
         provider: spawn
         toolName: subagent
+        modelSelectionSettings: true
         backgroundMode: continuable
 
     - id: tool-subagent-fork
@@ -313,7 +314,7 @@
       config:
         provider: codex
         toolName: subagent_codex
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: tool-subagent-claude-code
@@ -322,7 +323,7 @@
       config:
         provider: claude-code
         toolName: subagent_claude_code
-        enableRunInBackground: false
+        backgroundMode: one-shot
         maxDepth: provider-managed
 
     - id: workflow-worker-thread

--- a/zero-anchored-standard/dev-tool-search.mjs
+++ b/zero-anchored-standard/dev-tool-search.mjs
@@ -55,7 +55,7 @@ function toJsonSchema(spec) {
  */
 const UNLOCKABLE_INDEX = [
   'web_search — internet search and web retrieval',
-  'subagent / subagent_fork — delegate work to sub-agents',
+  'subagent / subagent_fork / list_subagent_models — delegate work to sub-agents and choose their LLM',
   'workflow — run multi-agent workflow scripts',
   'ralph — fresh-agent iterative loop',
   'create_goal / get_goal / update_goal — long-running goals',


### PR DESCRIPTION
## Summary

Aligns the anchored-standard plugin's subagent delegation configuration with the latest dsh alpha (`0.1.2-alpha.3`). No behavioral change to the anchored bootstrap/anchor flow; only the subagent interface is brought in sync with upstream.

## Changes

All 7 `agent.cordis.yml` presets (`preset`, `zero-anchored-standard`, `whoami-standard`, `combo-anchored`, `eternal-minimal`, `prefab`, `wire-think-standard`):

- `tool-subagent` (spawn): add `modelSelectionSettings: true` — enables the optional `provider` / `model` / `reasoning_effort` child-selection fields and registers the shared `list_subagent_models` discovery tool.
- `tool-subagent-codex` / `tool-subagent-claude-code` (disabled rows): replace the removed `enableRunInBackground: false` key with `backgroundMode: one-shot` (matches the current dsh `tool-subagent` config schema; stays `disabled: true` with `maxDepth: provider-managed`).

Plus `shared/dev-tool-search.mjs` (and its synced copies):

- Advertise `list_subagent_models` alongside `subagent / subagent_fork` so the new model-selection tool is discoverable through `dev_tool_search`.

## Validation

- `npm run sync` — all mode copies match `shared/`.
- `npm test` — 214/214 pass.
- Verified against dsh `0.1.2-alpha.3` source: all delegation rows match the official `standard` preset; plugin event APIs (`session/event`, `system-prompt/assemble` + `context.agent`, `agent/pre-step`, `agent/inbox/inserted`, `agent.inject`, `ctx.tools.schemas`, `ctx.skills`, `ctx.fs`, `ctx.subprocess`) remain compatible.