### PR TITLE
fix: support session.snapshotEvents() in DSH presets

### DIFF
--- a/combo-anchored/compaction-epoch.mjs
+++ b/combo-anchored/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/combo-anchored/deliberation-gate.mjs
+++ b/combo-anchored/deliberation-gate.mjs
@@ -112,8 +112,8 @@ export function apply(ctx, config) {
     let entry = state.get(session.id)
     if (entry === undefined) {
       entry = { turns: new Map(), lastTurn: -1 }
-      if (Array.isArray(session.events)) {
-        for (const event of session.events) {
+      if (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) {
+        for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
           if (event.type !== 'assistant/chunk') continue
           const turn = event.data?.turn
           if (typeof turn !== 'number' || !Number.isFinite(turn)) continue

--- a/combo-anchored/instruction-hint.mjs
+++ b/combo-anchored/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/combo-anchored/think-phase.mjs
+++ b/combo-anchored/think-phase.mjs
@@ -116,8 +116,8 @@ export function apply(ctx, config) {
     let entry = state.get(session.id)
     if (entry === undefined) {
       const steered = new Set()
-      if (Array.isArray(session.events)) {
-        for (const event of session.events) {
+      if (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) {
+        for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
           if (event.type !== 'steering/message') continue
           if (event.data?.source?.plugin === name && typeof event.data?.turn === 'number') {
             steered.add(event.data.turn)
@@ -148,8 +148,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args
@@ -175,7 +175,7 @@ export function apply(ctx, config) {
     if (entry === undefined) return decision
     entry.turn = turn
     const subagent = (agent.session.header?.delegationDepth ?? 0) > 0
-    const firstUserTurn = !Array.isArray(agent.session.events) || !agent.session.events.some((event) => event.type === 'user/message')
+    const firstUserTurn = !Array.isArray((agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) || !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
     const think = step === 0
       && (!subagent || includeSubagents)
       && (mode === 'every-turn' || firstUserTurn)

--- a/eternal-minimal/compaction-epoch.mjs
+++ b/eternal-minimal/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/eternal-minimal/instruction-hint.mjs
+++ b/eternal-minimal/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/prefab/compaction-epoch.mjs
+++ b/prefab/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/prefab/instruction-hint.mjs
+++ b/prefab/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/prefab/prefab-session-seed.mjs
+++ b/prefab/prefab-session-seed.mjs
@@ -408,7 +408,7 @@ export function synchronizeAgentTurnCursor(agent, session) {
   if (agent.status !== 'idle' || phase?.kind !== 'idle' || !Number.isSafeInteger(phase.lastTurn)) {
     throw new Error(`${name}: live agent is not an idle compatible ReactLoopAgent`)
   }
-  const lastTurn = session.events.findLast((event) => event.type === 'turn/start')?.data?.turn ?? 0
+  const lastTurn = (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])).findLast((event) => event.type === 'turn/start')?.data?.turn ?? 0
   if (!Number.isSafeInteger(lastTurn) || lastTurn < 0) {
     throw new Error(`${name}: seeded transcript has an invalid final turn`)
   }
@@ -418,7 +418,7 @@ export function synchronizeAgentTurnCursor(agent, session) {
 
 /** Append the compact template while remapping retained provenance seqs. */
 export function seedSession(session, plan, title = READY_TITLE) {
-  if (session.events.some((event) => event.type === 'turn/start')) return false
+  if ((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])).some((event) => event.type === 'turn/start')) return false
 
   const seqMap = new Map()
   for (const sourceEvent of plan) {
@@ -463,7 +463,7 @@ export function apply(ctx, config = {}) {
     const selected = event.type === 'agent-preset/selected' && event.data?.agentPreset === presetId
     const born = event.type === 'permission/preset' && session.header?.agentPreset === presetId
     if (!selected && !born) return
-    if (scheduled.has(session) || session.events.some((item) => item.type === 'turn/start')) return
+    if (scheduled.has(session) || (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])).some((item) => item.type === 'turn/start')) return
     scheduled.add(session)
 
     // The selection event is still being published here. A microtask is the
@@ -475,7 +475,7 @@ export function apply(ctx, config = {}) {
     queueMicrotask(() => {
       ;(async () => {
         try {
-          if (session.events.some((item) => item.type === 'turn/start')) return
+          if ((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])).some((item) => item.type === 'turn/start')) return
           const agent = ctx.get('agents')?.get(session.id)
           // ReactLoopAgent snapshots the final turn in its constructor. Preset
           // selection happens later, so validate that cursor before appending a

--- a/prefab/probe-clone-runner.mjs
+++ b/prefab/probe-clone-runner.mjs
@@ -87,12 +87,12 @@ async function run(ctx, config, io) {
   // The seeder hydrates asynchronously (skill re-render); a seeded session
   // carries the template's turn/start events.
   const deadline = Date.now() + config.seedTimeoutMs
-  while (Date.now() < deadline && !agent.session.events.some((event) => event.type === 'turn/start')) {
+  while (Date.now() < deadline && !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'turn/start')) {
     await sleep(25)
   }
-  const seeded = agent.session.events.some((event) => event.type === 'turn/start')
-  const seededTurns = agent.session.events.filter((event) => event.type === 'turn/start').length
-  const seededUnlocks = agent.session.events.some((event) =>
+  const seeded = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'turn/start')
+  const seededTurns = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).filter((event) => event.type === 'turn/start').length
+  const seededUnlocks = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) =>
     event.type === 'tool/call' && event.data?.name === 'dev_tool_search')
   if (!seeded) {
     internals.stdout.write(`PROBE_RESULT: ${JSON.stringify({ ok: false, error: 'session did not seed within timeout', sessionId: String(agent.session.id) })}\n`)
@@ -106,7 +106,7 @@ async function run(ctx, config, io) {
   let cancelled = false
   const watch = setInterval(() => {
     if (cancelled) return
-    const hit = agent.session.events.some((event) => event.type === 'assistant/message' && event.seq >= startSeq)
+    const hit = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'assistant/message' && event.seq >= startSeq)
     if (hit) {
       cancelled = true
       agent.cancel({ kind: 'user' })
@@ -121,7 +121,7 @@ async function run(ctx, config, io) {
   clearInterval(watch)
   await sessions.flush(agent.session)
 
-  const first = agent.session.events.find((event) => event.type === 'assistant/message' && event.seq >= startSeq)
+  const first = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).find((event) => event.type === 'assistant/message' && event.seq >= startSeq)
   if (first === undefined) {
     internals.stdout.write(`PROBE_RESULT: ${JSON.stringify({ ok: false, error: 'no assistant message recorded', sessionId: String(agent.session.id), seeded: true })}\n`)
     io.exit(5)

--- a/prefab/roll-runner.mjs
+++ b/prefab/roll-runner.mjs
@@ -88,7 +88,7 @@ async function run(ctx, config, io) {
   const messages = []
   const collectedSeqs = new Set()
   const collect = () => {
-    for (const event of agent.session.events) {
+    for (const event of (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) {
       if (event.seq < startSeq || event.type !== 'assistant/message') continue
       if (collectedSeqs.has(event.seq)) continue
       const reasoning = (event.data.message?.content ?? []).find((block) => block.type === 'reasoning')
@@ -122,7 +122,7 @@ async function run(ctx, config, io) {
   // The anchor turn's FIRST block is the trajectory the whole template sells:
   // it must open in the collaborative voice even when later steps narrate.
   const anchorWeFirst = classified.length > 0 && classified[0].weFirst
-  const effectiveReasoningCount = agent.session.events.filter((event) =>
+  const effectiveReasoningCount = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).filter((event) =>
     event.seq >= startSeq
     && event.type === 'assistant/message'
     && event.data.message?.content?.some((block) => block.type === 'reasoning')
@@ -132,7 +132,7 @@ async function run(ctx, config, io) {
   let unlockedNames = []
   let readAgentsMd = false
   let skillSearched = false
-  for (const event of agent.session.events) {
+  for (const event of (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) {
     if (event.seq < startSeq) continue
     if (event.type !== 'tool/call') continue
     if (event.data.name === 'dev_tool_search') {

--- a/prefab/tool-bootstrap.mjs
+++ b/prefab/tool-bootstrap.mjs
@@ -207,8 +207,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/preset/compaction-epoch.mjs
+++ b/preset/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/preset/instruction-hint.mjs
+++ b/preset/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/preset/tool-bootstrap.mjs
+++ b/preset/tool-bootstrap.mjs
@@ -207,8 +207,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/shared/anchor-turn.mjs
+++ b/shared/anchor-turn.mjs
@@ -32,7 +32,7 @@ export const ANCHOR_TEXT = 'This round is a test. Tools are not open yet; all to
 /** Fresh sessions (no prior user message) get the anchor turn. */
 function isFreshSession(agent, includeSubagents = false) {
   if (!includeSubagents && (agent.session.header.delegationDepth ?? 0) > 0) return false
-  return !agent.session.events.some((event) => event.type === 'user/message')
+  return !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
 }
 
 /** Register the first-message anchor injection. */

--- a/shared/compaction-epoch.mjs
+++ b/shared/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/shared/deliberation-gate.mjs
+++ b/shared/deliberation-gate.mjs
@@ -112,8 +112,8 @@ export function apply(ctx, config) {
     let entry = state.get(session.id)
     if (entry === undefined) {
       entry = { turns: new Map(), lastTurn: -1 }
-      if (Array.isArray(session.events)) {
-        for (const event of session.events) {
+      if (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) {
+        for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
           if (event.type !== 'assistant/chunk') continue
           const turn = event.data?.turn
           if (typeof turn !== 'number' || !Number.isFinite(turn)) continue

--- a/shared/instruction-hint.mjs
+++ b/shared/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/shared/think-phase.mjs
+++ b/shared/think-phase.mjs
@@ -116,8 +116,8 @@ export function apply(ctx, config) {
     let entry = state.get(session.id)
     if (entry === undefined) {
       const steered = new Set()
-      if (Array.isArray(session.events)) {
-        for (const event of session.events) {
+      if (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) {
+        for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
           if (event.type !== 'steering/message') continue
           if (event.data?.source?.plugin === name && typeof event.data?.turn === 'number') {
             steered.add(event.data.turn)
@@ -148,8 +148,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args
@@ -175,7 +175,7 @@ export function apply(ctx, config) {
     if (entry === undefined) return decision
     entry.turn = turn
     const subagent = (agent.session.header?.delegationDepth ?? 0) > 0
-    const firstUserTurn = !Array.isArray(agent.session.events) || !agent.session.events.some((event) => event.type === 'user/message')
+    const firstUserTurn = !Array.isArray((agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) || !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
     const think = step === 0
       && (!subagent || includeSubagents)
       && (mode === 'every-turn' || firstUserTurn)

--- a/shared/tool-bootstrap.mjs
+++ b/shared/tool-bootstrap.mjs
@@ -207,8 +207,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/shared/wire-think.mjs
+++ b/shared/wire-think.mjs
@@ -116,8 +116,8 @@ export function apply(ctx, config) {
     let entry = state.get(session.id)
     if (entry === undefined) {
       const steered = new Set()
-      if (Array.isArray(session.events)) {
-        for (const event of session.events) {
+      if (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) {
+        for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
           if (event.type !== 'steering/message') continue
           if (event.data?.source?.plugin === name && typeof event.data?.turn === 'number') {
             steered.add(event.data.turn)
@@ -163,8 +163,8 @@ export function apply(ctx, config) {
   /** Tool names the model explicitly unlocked via `dev_tool_search` (execute phase). */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args
@@ -188,7 +188,7 @@ export function apply(ctx, config) {
     if (entry === undefined) return decision
     entry.turn = turn
     const subagent = (agent.session.header?.delegationDepth ?? 0) > 0
-    const firstUserTurn = !Array.isArray(agent.session.events) || !agent.session.events.some((event) => event.type === 'user/message')
+    const firstUserTurn = !Array.isArray((agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) || !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
     const think = step === 0
       && (!subagent || includeSubagents)
       && (mode === 'every-turn' || firstUserTurn)

--- a/shared/zero-tool-bootstrap.mjs
+++ b/shared/zero-tool-bootstrap.mjs
@@ -114,8 +114,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/verify/verify-runner.mjs
+++ b/verify/verify-runner.mjs
@@ -123,11 +123,11 @@ async function run(ctx, config, io) {
   out.push(`sessionId: ${agent.session.id}`)
   out.push(`preset: ${config.preset}`)
   out.push(`cwd: ${config.cwd}`)
-  for (const event of agent.session.events) {
+  for (const event of (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) {
     if (event.type !== 'request/header') continue
     out.push(`request/header [${event.data.reason}] ${headerLine(event.data.header)}`)
   }
-  const firstAssistant = agent.session.events.find((event) => event.type === 'assistant/message' && event.seq >= firstSeq)
+  const firstAssistant = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).find((event) => event.type === 'assistant/message' && event.seq >= firstSeq)
   if (firstAssistant === undefined) {
     out.push('(no assistant/message recorded)')
   } else {
@@ -141,14 +141,14 @@ async function run(ctx, config, io) {
   }
   // Which user-message sources reached the first step: the bootstrap strip
   // removes agent-instructions and skill-catalog until promotion.
-  const beforeAssistant = agent.session.events.filter(
+  const beforeAssistant = (agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).filter(
     (event) => event.seq >= firstSeq && event.seq < (firstAssistant?.seq ?? Number.POSITIVE_INFINITY),
   )
   const userSources = beforeAssistant
     .filter((event) => event.type === 'user/message')
     .map((event) => event.data.message?.source?.kind ?? 'unknown')
   out.push(`first-step user message sources: ${JSON.stringify(userSources)}`)
-  const turnEnd = [...agent.session.events].reverse().find((event) => event.type === 'turn/end')
+  const turnEnd = [...(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))].reverse().find((event) => event.type === 'turn/end')
   out.push(`turn/end: ${JSON.stringify(turnEnd?.data?.reason ?? null)}`)
   io.stdout.write(out.join('\n') + '\n')
   io.exit(0)

--- a/whoami-standard/anchor-turn.mjs
+++ b/whoami-standard/anchor-turn.mjs
@@ -32,7 +32,7 @@ export const ANCHOR_TEXT = 'This round is a test. Tools are not open yet; all to
 /** Fresh sessions (no prior user message) get the anchor turn. */
 function isFreshSession(agent, includeSubagents = false) {
   if (!includeSubagents && (agent.session.header.delegationDepth ?? 0) > 0) return false
-  return !agent.session.events.some((event) => event.type === 'user/message')
+  return !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
 }
 
 /** Register the first-message anchor injection. */

--- a/whoami-standard/compaction-epoch.mjs
+++ b/whoami-standard/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/whoami-standard/instruction-hint.mjs
+++ b/whoami-standard/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/whoami-standard/zero-tool-bootstrap.mjs
+++ b/whoami-standard/zero-tool-bootstrap.mjs
@@ -114,8 +114,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args

--- a/wire-think-standard/compaction-epoch.mjs
+++ b/wire-think-standard/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/wire-think-standard/instruction-hint.mjs
+++ b/wire-think-standard/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/wire-think-standard/wire-think.mjs
+++ b/wire-think-standard/wire-think.mjs
@@ -116,8 +116,8 @@ export function apply(ctx, config) {
     let entry = state.get(session.id)
     if (entry === undefined) {
       const steered = new Set()
-      if (Array.isArray(session.events)) {
-        for (const event of session.events) {
+      if (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) {
+        for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
           if (event.type !== 'steering/message') continue
           if (event.data?.source?.plugin === name && typeof event.data?.turn === 'number') {
             steered.add(event.data.turn)
@@ -163,8 +163,8 @@ export function apply(ctx, config) {
   /** Tool names the model explicitly unlocked via `dev_tool_search` (execute phase). */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args
@@ -188,7 +188,7 @@ export function apply(ctx, config) {
     if (entry === undefined) return decision
     entry.turn = turn
     const subagent = (agent.session.header?.delegationDepth ?? 0) > 0
-    const firstUserTurn = !Array.isArray(agent.session.events) || !agent.session.events.some((event) => event.type === 'user/message')
+    const firstUserTurn = !Array.isArray((agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? []))) || !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
     const think = step === 0
       && (!subagent || includeSubagents)
       && (mode === 'every-turn' || firstUserTurn)

--- a/zero-anchored-standard/anchor-turn.mjs
+++ b/zero-anchored-standard/anchor-turn.mjs
@@ -32,7 +32,7 @@ export const ANCHOR_TEXT = 'This round is a test. Tools are not open yet; all to
 /** Fresh sessions (no prior user message) get the anchor turn. */
 function isFreshSession(agent, includeSubagents = false) {
   if (!includeSubagents && (agent.session.header.delegationDepth ?? 0) > 0) return false
-  return !agent.session.events.some((event) => event.type === 'user/message')
+  return !(agent.session.snapshotEvents ? agent.session.snapshotEvents() : (agent.session.events ?? [])).some((event) => event.type === 'user/message')
 }
 
 /** Register the first-message anchor injection. */

--- a/zero-anchored-standard/compaction-epoch.mjs
+++ b/zero-anchored-standard/compaction-epoch.mjs
@@ -33,7 +33,7 @@ export function createEpochPromotion(promoteEvents, options = {}) {
   const scan = (session) => {
     let boundary = -1
     let promoted = false
-    for (const event of session.events) {
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       const seq = event.seq ?? 0 // events without a seq are treated as post-boundary
       if (event.type === 'compaction/end') {
         boundary = seq

--- a/zero-anchored-standard/instruction-hint.mjs
+++ b/zero-anchored-standard/instruction-hint.mjs
@@ -162,7 +162,7 @@ export function apply(ctx, config) {
   const hintIsDurable = (session) => {
     const known = hinted.get(session.id)
     if (known !== undefined) return known
-    const found = (Array.isArray(session.events) ? session.events : []).some((event) =>
+    const found = (Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) ? (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])) : []).some((event) =>
       event.type === 'user/message' && event.data?.source?.kind === 'instruction-hint',
     )
     hinted.set(session.id, found)

--- a/zero-anchored-standard/zero-tool-bootstrap.mjs
+++ b/zero-anchored-standard/zero-tool-bootstrap.mjs
@@ -114,8 +114,8 @@ export function apply(ctx, config) {
    */
   const unlockedFor = (session) => {
     const unlocked = new Set()
-    if (session === undefined || !Array.isArray(session.events)) return unlocked
-    for (const event of session.events) {
+    if (session === undefined || !Array.isArray((session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])))) return unlocked
+    for (const event of (session.snapshotEvents ? session.snapshotEvents() : (session.events ?? []))) {
       if (event.type !== 'tool/call') continue
       if (event.data?.name !== 'dev_tool_search') continue
       let args


### PR DESCRIPTION
DeepSeek Harness has removed the direct `session.events` array and now provides `session.snapshotEvents()`. This caused preset plugins that scan session history to fail, so Prefab and other anchored presets could not seed/inject context correctly after a DSH update.

This PR updates all preset plugin files and verify helpers to use:

```js
session.snapshotEvents ? session.snapshotEvents() : (session.events ?? [])
```

and the equivalent for `agent.session.events`.

It keeps compatibility with older DSH versions that still expose `session.events`.

Verification:
- `npm test` passes: 214/214
