### PR TITLE
fix: migrate persona rows from `text:` to `prefix:` for dsh-persona 0.1.3

### DIFF
--- a/combo-anchored/agent.cordis.yml
+++ b/combo-anchored/agent.cordis.yml
@@ -50,7 +50,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -371,3 +371,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+

--- a/eternal-minimal/agent.cordis.yml
+++ b/eternal-minimal/agent.cordis.yml
@@ -56,7 +56,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -291,3 +291,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+

--- a/prefab/agent.cordis.yml
+++ b/prefab/agent.cordis.yml
@@ -105,7 +105,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -434,3 +434,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+

--- a/preset/agent.cordis.yml
+++ b/preset/agent.cordis.yml
@@ -99,7 +99,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -439,3 +439,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+

--- a/whoami-standard/agent.cordis.yml
+++ b/whoami-standard/agent.cordis.yml
@@ -50,7 +50,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -368,3 +368,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+

--- a/wire-think-standard/agent.cordis.yml
+++ b/wire-think-standard/agent.cordis.yml
@@ -60,7 +60,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -335,3 +335,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+

--- a/zero-anchored-standard/agent.cordis.yml
+++ b/zero-anchored-standard/agent.cordis.yml
@@ -45,7 +45,7 @@
 - id: persona
   name: '@deepseek-ai/dsh-persona'
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
 
@@ -357,3 +357,4 @@
   config:
     fetch: false
     searchTimeoutMs: 60000
+


### PR DESCRIPTION
## What

Migrates every mode directory's `persona` row from the removed `text:` key to the required `prefix:` key of `@deepseek-ai/dsh-persona` 0.1.3. The persona **text** is unchanged — only the config key moves.

Closes #89.

## Why

dsh-persona 0.1.3-alpha.x replaced its config schema with:

```js
const Config = z.object({
	prefix: z.string().required(),
	suffix: z.string().default(""),
	complete: z.boolean().default(false),
	includeRuntimeContext: z.boolean().default(true)
});
```

There is no `text` key anymore, so every preset that ships the old key now fails to mount on 0.1.3 with `invalid config: $.prefix missing required value`, and resume breaks for sessions that already selected the preset. PR #88 aligned the session-log scans for 0.1.3; this fixes the remaining mount blocker.

## Change

In all seven `agent.cordis.yml` files (preset, zero-anchored-standard, whoami-standard, combo-anchored, eternal-minimal, wire-think-standard, prefab):

```diff
   config:
-    text: You are a helpful software engineer assistant.
+    prefix: You are a helpful software engineer assistant.
     complete: true
     includeRuntimeContext: false
```

The fixed row matches the official 0.1.3 `minimal` preset's persona row byte-for-byte, so the Minimal anchor condition (byte-pure persona) is unaffected.

## Verification

- `npm run check`: **223/223 pass** (includes the materialized-copy sync gate).
- Checked against the installed `@deepseek-ai/dsh-persona` 0.1.3-alpha.2 zod schema: old config rejected, new config accepted; preset mounts and creates sessions normally afterwards.
- Environment: DSH 0.1.3-alpha.2, Windows 11, Node 24.